### PR TITLE
Add MIT License file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 YuSabo90002
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds the missing MIT License file to the repository.

## Changes

- Add `LICENSE` file with standard MIT License text
- Copyright holder: YuSabo90002
- Copyright year: 2025

## Context

- `pyproject.toml` declares `license = "MIT"` but LICENSE file was missing
- `README.md` links to `LICENSE` file that didn't exist: "MIT License - see [LICENSE](LICENSE) file for details."
- This ensures proper license information is available in the repository and PyPI package
- GitHub will now automatically detect and display the license

## Impact

- ✅ Fixes broken link in README.md
- ✅ Provides complete license information for users and contributors
- ✅ Ensures PyPI package includes proper license file
- ✅ Enables GitHub's automatic license recognition

## Checklist

- [x] LICENSE file follows standard MIT License format
- [x] Copyright information matches repository owner
- [x] Fixes broken link in README.md
- [x] No code changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)