### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-10-23
+
 ### Added
 - **Additional Code Block Options Support** ([#31](https://github.com/YuSabo90002/sphinxcontrib-typst/issues/31))
   - Added support for `:lineno-start:` option to specify starting line number for code blocks
@@ -43,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Document files now include `#import "@preview/codly:1.3.0": *` and `#import "@preview/codly-languages:0.1.1": *`
   - Enables PDF generation for documents with code blocks (prerequisite for Issue #20)
   - No breaking changes - only adds imports alongside existing mitex/gentle-clues imports
+
+### Documentation
+- **README Math Example Fix** ([#33](https://github.com/YuSabo90002/sphinxcontrib-typst/pull/33))
+  - Fixed incorrect double-escaped backslashes in math directive example
+  - Changed `\\int` to `\int` for correct reStructuredText syntax
+  - Helps users write proper reStructuredText files
 
 ## [0.2.1] - 2025-10-18
 

--- a/README.md
+++ b/README.md
@@ -306,5 +306,5 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 ---
 
-**Status**: Stable (v0.2.1) - Production ready
+**Status**: Stable (v0.2.2) - Production ready
 **Python**: 3.9+ | **Sphinx**: 5.0+ | **Typst**: 0.11.1+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphinxcontrib-typst"
-version = "0.2.1"
+version = "0.2.2"
 description = "Sphinx extension for Typst output"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sphinxcontrib/typst/__init__.py
+++ b/sphinxcontrib/typst/__init__.py
@@ -11,7 +11,7 @@ sources using Sphinx, which can then be compiled to PDF using the Typst compiler
 :license: MIT, see LICENSE for details.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Sphinx Typst Contributors"
 
 from typing import Any, Dict


### PR DESCRIPTION
## Release v0.2.2

This PR bumps the version to 0.2.2 and prepares for release.

## Version Changes

- `pyproject.toml`: 0.2.1 → 0.2.2
- `sphinxcontrib/typst/__init__.py`: 0.2.1 → 0.2.2
- `README.md`: Updated status badge to v0.2.2
- `CHANGELOG.md`: Added v0.2.2 release notes

## Release Highlights

### Added
- **:lineno-start: and :dedent: code-block options** (#31)
  - Specify starting line number for code blocks
  - Automatic dedent handling by Sphinx
  - Now supports 6/8 (75%) standard Sphinx code-block options
  - 7 new comprehensive test cases

- **Raw directive support** (#25)
  - Support for `.. raw:: typst` directive
  - Pass-through Typst-specific content
  - 6 new test cases

### Fixed
- **Code-block directive options** (#20)
  - Fixed :linenos:, :caption:, :name: options
  - Proper line number control
  - Figure wrapping for captions
  - Label generation for cross-references

- **PDF builder codly import** (#28)
  - Fixed "unknown variable: codly" error
  - Added codly imports to document templates

### Documentation
- **README math example fix** (#33)
  - Fixed double-escaped backslashes in math example
  - Corrected reStructuredText syntax

## Merged PRs

- #32: feat: add support for :lineno-start: and :dedent: code-block options
- #33: docs: fix math directive example in README

## Testing

- ✅ All 339 tests pass
- ✅ Code coverage: 73% (translator.py)
- ✅ Quality checks: mypy, ruff, black all pass
- ✅ Integration tests verified

## Next Steps

After merging:
1. Create git tag `v0.2.2`
2. Push tag to trigger GitHub release
3. Publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)