### PR TITLE
refactor: migrate CI to tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run tests
-        run: uv run pytest tests/ -v
+      - name: Run tests with tox
+        run: uv run tox -e py${{ matrix.python-version }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -61,11 +61,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run black
-        run: uv run black --check .
-
-      - name: Run ruff
-        run: uv run ruff check .
+      - name: Run lint with tox
+        run: uv run tox -e lint
 
   type-check:
     name: Type Check
@@ -85,8 +82,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run mypy
-        run: uv run mypy typsphinx/
+      - name: Run type check with tox
+        run: uv run tox -e type
 
   coverage:
     name: Code Coverage
@@ -106,8 +103,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run coverage
-        run: uv run pytest --cov=typsphinx --cov-report=term-missing --cov-report=xml --cov-report=html tests/
+      - name: Run coverage with tox
+        run: uv run tox -e cov -- --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,18 +28,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra docs
+          uv sync --extra dev
           uv pip install -e .
 
-      - name: Build HTML documentation
-        run: |
-          cd docs
-          uv run sphinx-build -b html source _build/html
+      - name: Build HTML documentation with tox
+        run: uv run tox -e docs-html
 
-      - name: Build PDF documentation
-        run: |
-          cd docs
-          uv run sphinx-build -b typstpdf source _build/pdf
+      - name: Build PDF documentation with tox
+        run: uv run tox -e docs-pdf
 
       - name: Upload HTML artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Migrate CI to Tox**
+  - GitHub Actions workflows now use tox commands for consistency
+  - Added `docs-html`, `docs-pdf`, and `docs` tox environments
+  - Simplified CI configuration with single source of truth in `tox.ini`
+  - Improved local/CI consistency - same commands work in both environments
+  - Updated test, lint, type-check, and coverage jobs to use tox
+  - Documentation builds now reproducible locally with `tox -e docs-html` or `tox -e docs-pdf`
+  - Fixed paths in existing tox environments (sphinxcontrib/ → typsphinx/)
+
 ### Added
 
 - **Documentation Site with GitHub Pages** ([#36](https://github.com/YuSabo90002/typsphinx/issues/36))

--- a/README.md
+++ b/README.md
@@ -228,10 +228,13 @@ uv run pytest --cov=typsphinx --cov-report=html
 # Run tests across multiple Python versions
 uv run tox
 
-# Run linters
-uv run black .
-uv run ruff check .
-uv run mypy sphinxcontrib/
+# Run specific tox environments
+uv run tox -e lint          # Run linters (black, ruff)
+uv run tox -e type          # Run type checking (mypy)
+uv run tox -e py311         # Run tests on Python 3.11
+uv run tox -e docs-html     # Build HTML documentation
+uv run tox -e docs-pdf      # Build PDF documentation
+uv run tox -e docs          # Build both HTML and PDF docs
 ```
 
 ### Testing Strategy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
+    "typsphinx",
 ]
 
 templates_path = ["_templates"]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -105,6 +105,34 @@ Run all quality checks:
    uv run mypy typsphinx/
    uv run pytest --cov
 
+Using Tox
+~~~~~~~~~
+
+We use tox for running tests across multiple Python versions and environments.
+Tox provides the same commands used in CI, making it easy to reproduce issues locally:
+
+.. code-block:: bash
+
+   # Run all tox environments (tests, lint, type check, docs)
+   uv run tox
+
+   # Run specific environments
+   uv run tox -e lint          # Black + Ruff
+   uv run tox -e type          # Mypy type checking
+   uv run tox -e py311         # Tests on Python 3.11
+   uv run tox -e docs-html     # Build HTML documentation
+   uv run tox -e docs-pdf      # Build PDF documentation
+   uv run tox -e docs          # Build both HTML and PDF
+
+   # Run tests on specific Python versions
+   uv run tox -e py39,py310,py311,py312
+
+The tox configuration is defined in ``tox.ini`` and provides:
+
+- Consistent test execution across local and CI environments
+- Isolated virtual environments for each test run
+- Same commands work locally and in GitHub Actions
+
 Development Workflow
 --------------------
 

--- a/openspec/changes/migrate-ci-to-tox/proposal.md
+++ b/openspec/changes/migrate-ci-to-tox/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: Migrate CI to Tox
+
+## Why
+
+現在、GitHub Actionsワークフローは各ジョブで個別にコマンドを実行しており、以下の課題があります：
+
+1. **重複したコマンド定義**: テスト、lint、type checkなどのコマンドがGitHub ActionsとローカルTODOで重複
+2. **ローカル再現性の問題**: CI失敗時にローカルで同じ環境を再現しにくい
+3. **メンテナンスコスト**: 変更時に複数のワークフローファイルを更新する必要がある
+4. **ドキュメントビルドの未検証**: 現在、ドキュメントビルド（HTML/PDF）がtoxで実行できない
+
+toxを活用することで：
+
+- **単一の真実の源**: tox.iniでコマンドを一元管理
+- **ローカル/CI一貫性**: 同じtoxコマンドをローカルとCIで実行
+- **簡潔なワークフロー**: GitHub Actionsは`tox`コマンドを呼ぶだけ
+- **検証容易性**: ローカルで`tox`を実行すればCI環境を再現
+
+## What Changes
+
+### 1. tox.iniの拡張
+
+新しいtox環境を追加：
+
+- `docs-html`: HTMLドキュメントビルド
+- `docs-pdf`: PDFドキュメントビルド（typstpdf）
+- `docs`: 両方のドキュメントビルド
+
+### 2. GitHub Actionsワークフローの簡素化
+
+**ci.yml**: 既存のtest/lint/type-checkジョブをtox経由に変更
+
+**docs.yml**: ドキュメントビルドをtox経由に変更
+
+### 3. conf.pyの修正
+
+`docs/source/conf.py`の`extensions`に`typsphinx`を追加（PDFビルドに必要）
+
+## Impact
+
+### Affected specs
+
+既存specの修正：
+- `package-structure`: CI/CD設定の変更
+
+新規specの追加：
+- なし（既存の範囲内）
+
+### Affected code
+
+変更ファイル：
+- `tox.ini` - 新しいdocs環境追加
+- `.github/workflows/ci.yml` - toxコマンド経由に変更
+- `.github/workflows/docs.yml` - toxコマンド経由に変更
+- `docs/source/conf.py` - typsphinx extension追加
+
+### Breaking changes
+
+なし - 外部APIや動作に変更なし
+
+## Alternatives Considered
+
+1. **現状維持**: GitHub Actionsで直接コマンド実行
+   - 問題: ローカル再現性が低く、メンテナンスコストが高い
+
+2. **Makefileの使用**: makeコマンドでタスク管理
+   - 問題: Python環境管理がtoxより弱い
+
+3. **カスタムスクリプト**: scripts/ディレクトリにシェルスクリプト
+   - 問題: 標準化されていない、toxのような環境分離がない
+
+toxを選択した理由：
+- Pythonプロジェクトの標準的なツール
+- 環境分離が優れている
+- 既存のtox設定を活用できる
+- ローカル/CI両方で同じコマンド

--- a/openspec/changes/migrate-ci-to-tox/specs/package-structure/spec.md
+++ b/openspec/changes/migrate-ci-to-tox/specs/package-structure/spec.md
@@ -1,0 +1,84 @@
+# Capability: package-structure
+
+## MODIFIED Requirements
+
+### Requirement: CI/CD設定
+
+プロジェクトは、継続的インテグレーションとデプロイのための設定を提供しなければならない (SHALL)。
+
+**変更内容**: GitHub ActionsワークフローをTox経由で実行するように変更し、ローカル/CI一貫性を向上させる。
+
+#### Scenario: Toxベースのテスト実行
+
+- **GIVEN** tox.iniにテスト環境が定義されている
+- **WHEN** GitHub Actionsのtestジョブが実行される
+- **THEN** `tox -e py{39,310,311,312}`コマンドが使用される
+- **AND** ローカルで同じtoxコマンドを実行すると同じ結果が得られる
+
+#### Scenario: Toxベースのlint実行
+
+- **GIVEN** tox.iniにlint環境が定義されている
+- **WHEN** GitHub Actionsのlintジョブが実行される
+- **THEN** `tox -e lint`コマンドが使用される
+- **AND** black、ruffチェックが実行される
+
+#### Scenario: Toxベースの型チェック
+
+- **GIVEN** tox.iniにtype環境が定義されている
+- **WHEN** GitHub Actionsのtype-checkジョブが実行される
+- **THEN** `tox -e type`コマンドが使用される
+- **AND** mypyによる型チェックが実行される
+
+#### Scenario: Toxベースのドキュメントビルド
+
+- **GIVEN** tox.iniにdocs-html、docs-pdf環境が定義されている
+- **WHEN** GitHub Actionsのdocsジョブが実行される
+- **THEN** `tox -e docs-html`でHTMLが、`tox -e docs-pdf`でPDFがビルドされる
+- **AND** ローカルで同じtoxコマンドを実行すると同じ出力が得られる
+
+## ADDED Requirements
+
+### Requirement: Tox環境定義
+
+プロジェクトは、ドキュメントビルド用のTox環境を提供しなければならない (SHALL)。
+
+#### Scenario: HTMLドキュメントビルド環境
+
+- **GIVEN** tox.iniが存在する
+- **WHEN** `tox -e docs-html`を実行する
+- **THEN** Sphinxが実行されてHTMLドキュメントがビルドされる
+- **AND** 出力は`docs/_build/html/`に生成される
+- **AND** 必要な依存関係（furo、sphinx-autodoc-typehints）がインストールされる
+
+#### Scenario: PDFドキュメントビルド環境
+
+- **GIVEN** tox.iniが存在する
+- **WHEN** `tox -e docs-pdf`を実行する
+- **THEN** Sphinxがtypstpdfビルダーで実行される
+- **AND** 出力は`docs/_build/pdf/`に生成される
+- **AND** typsphinx拡張が正しくロードされる
+
+#### Scenario: 統合ドキュメントビルド環境
+
+- **GIVEN** tox.iniが存在する
+- **WHEN** `tox -e docs`を実行する
+- **THEN** HTMLとPDFの両方がビルドされる
+- **AND** いずれかのビルドが失敗した場合、toxは非ゼロ終了コードを返す
+
+### Requirement: ローカル/CI一貫性
+
+プロジェクトは、ローカル開発環境とCI環境で同じコマンドが使用できなければならない (SHALL)。
+
+#### Scenario: ローカルでCIと同じテスト実行
+
+- **GIVEN** 開発者がローカル環境にいる
+- **WHEN** `tox`を実行する
+- **THEN** CI環境と同じテスト、lint、型チェックが実行される
+- **AND** 結果はCI環境と一致する
+
+#### Scenario: CI失敗のローカル再現
+
+- **GIVEN** GitHub ActionsのCIジョブが失敗している
+- **WHEN** 開発者がローカルで該当するtox環境（例: `tox -e py311`）を実行する
+- **THEN** 同じエラーがローカルで再現できる
+- **AND** デバッグがローカル環境で可能になる

--- a/openspec/changes/migrate-ci-to-tox/tasks.md
+++ b/openspec/changes/migrate-ci-to-tox/tasks.md
@@ -1,0 +1,55 @@
+# Implementation Tasks: Migrate CI to Tox
+
+## 1. Update tox.ini
+
+- [x] 1.1 Add `docs-html` environment for HTML documentation build
+- [x] 1.2 Add `docs-pdf` environment for PDF documentation build
+- [x] 1.3 Add `docs` environment for both HTML and PDF builds
+- [x] 1.4 Update existing `type` environment path (sphinxcontrib/ → typsphinx/)
+- [x] 1.5 Update existing `cov` environment path (sphinxcontrib.typst → typsphinx)
+
+## 2. Update docs/source/conf.py
+
+- [x] 2.1 Add `typsphinx` to extensions list (required for PDF builds)
+
+## 3. Update GitHub Actions - ci.yml
+
+- [x] 3.1 Update test job to use `tox -e py{39,310,311,312}`
+- [x] 3.2 Update lint job to use `tox -e lint`
+- [x] 3.3 Update type-check job to use `tox -e type`
+- [x] 3.4 Update coverage job to use `tox -e cov`
+
+## 4. Update GitHub Actions - docs.yml
+
+- [x] 4.1 Update HTML build step to use `tox -e docs-html`
+- [x] 4.2 Update PDF build step to use `tox -e docs-pdf`
+- [x] 4.3 Update artifact paths to match tox output directories
+
+## 5. Local Testing
+
+- [x] 5.1 Test `tox -e lint` locally
+- [x] 5.2 Test `tox -e type` locally
+- [x] 5.3 Test `tox -e py311` locally
+- [x] 5.4 Test `tox -e docs-html` locally
+- [x] 5.5 Test `tox -e docs-pdf` locally (verify it completes)
+- [x] 5.6 Test `tox -e docs` locally
+
+## 6. CI Verification
+
+- [ ] 6.1 Verify all CI jobs pass on PR
+- [ ] 6.2 Verify documentation builds successfully
+- [ ] 6.3 Verify GitHub Pages deployment works
+- [ ] 6.4 Verify test matrix (Python 3.9-3.12, Linux/Mac/Windows)
+
+## 7. Documentation
+
+- [x] 7.1 Update README.md with tox commands
+- [x] 7.2 Update CHANGELOG.md
+- [x] 7.3 Update contributing.rst with tox usage
+
+## 8. Final Validation
+
+- [x] 8.1 Run full tox suite locally
+- [x] 8.2 Verify all tests pass
+- [x] 8.3 Verify documentation builds
+- [ ] 8.4 Confirm CI pipeline works end-to-end

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py39, py310, py311, py312, lint, type, cov
+env_list = py39, py310, py311, py312, lint, type, cov, docs
 isolated_build = True
 requires = tox-uv>=1.0
 
@@ -36,11 +36,40 @@ deps =
     types-docutils>=0.18
     docutils>=0.18
 commands =
-    mypy sphinxcontrib/
+    mypy typsphinx/
 
 [testenv:cov]
 description = Run tests with coverage
 deps =
     {[testenv]deps}
 commands =
-    pytest --cov=sphinxcontrib.typst --cov-report=term-missing --cov-report=html {posargs:tests/}
+    pytest --cov=typsphinx --cov-report=term-missing --cov-report=html {posargs:tests/}
+
+[testenv:docs-html]
+description = Build HTML documentation
+runner = uv-venv-lock-runner
+extras = docs
+changedir = docs
+commands =
+    sphinx-build -b html source _build/html
+
+[testenv:docs-pdf]
+description = Build PDF documentation with typstpdf
+runner = uv-venv-lock-runner
+extras = docs
+deps =
+    typst>=0.11.1
+changedir = docs
+commands =
+    sphinx-build -b typstpdf source _build/pdf
+
+[testenv:docs]
+description = Build both HTML and PDF documentation
+runner = uv-venv-lock-runner
+extras = docs
+deps =
+    typst>=0.11.1
+changedir = docs
+commands =
+    sphinx-build -b html source _build/html
+    sphinx-build -b typstpdf source _build/pdf


### PR DESCRIPTION
## 概要

GitHub ActionsワークフローをToxベースに移行し、ローカル/CI環境の一貫性を向上させました。

## 変更内容

### 1. tox.ini の拡張
- 新しいtox環境を追加：
  - `docs-html`: HTMLドキュメントビルド
  - `docs-pdf`: PDFドキュメントビルド（typstpdf）
  - `docs`: 両方のドキュメントビルド
- 既存環境のパスを修正：
  - `type` 環境: `sphinxcontrib/` → `typsphinx/`
  - `cov` 環境: `sphinxcontrib.typst` → `typsphinx`

### 2. GitHub Actions ワークフローの簡素化
- **ci.yml**: test、lint、type-check、coverageジョブをtox経由に変更
- **docs.yml**: HTMLとPDFビルドをtox経由に変更

### 3. conf.py の修正
- `typsphinx`拡張をextensionsリストに追加（PDFビルドに必要）

### 4. ドキュメント更新
- **README.md**: tox環境の使用例を追加
- **CHANGELOG.md**: 変更内容を記録
- **contributing.rst**: Tox使用方法のセクションを追加

## メリット

✅ **単一の真実の源**: tox.iniでコマンドを一元管理  
✅ **ローカル/CI一貫性**: 同じtoxコマンドをローカルとCIで実行可能  
✅ **簡潔なワークフロー**: GitHub Actionsはtoxコマンドを呼ぶだけ  
✅ **検証容易性**: ローカルでtoxを実行すればCI環境を再現可能  

## テスト状況

### ローカル検証 ✅
- `tox -e lint` - ✅ 成功
- `tox -e type` - ✅ 成功
- `tox -e py311` - ✅ 成功 (365 tests)
- `tox -e docs-html` - ✅ 成功
- `tox -e docs-pdf` - ✅ 成功 (Typstファイル生成完了)
- `tox -e docs` - ✅ 成功

### CI検証
PRマージ後、GitHub ActionsでCI/CDパイプライン全体を検証予定。

## 破壊的変更

なし - 外部APIや動作に変更なし

## OpenSpec

この変更は OpenSpec `migrate-ci-to-tox` に基づいています。

- Proposal: `openspec/changes/migrate-ci-to-tox/proposal.md`
- Spec: `openspec/changes/migrate-ci-to-tox/specs/package-structure/spec.md`
- Tasks: `openspec/changes/migrate-ci-to-tox/tasks.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)