### PR TITLE
feat: add support for API description nodes (autodoc)

### DIFF
--- a/openspec/changes/add-autodoc-node-support/proposal.md
+++ b/openspec/changes/add-autodoc-node-support/proposal.md
@@ -1,0 +1,162 @@
+# Proposal: Add Autodoc Node Support
+
+## Why
+
+現在、typsphinxはautodoc（Sphinx自動APIドキュメント生成拡張）が生成するノードタイプをサポートしていません。このため：
+
+1. **PDFビルド失敗**: API referenceページを含むドキュメントのPDFビルドが失敗
+2. **大量の警告**: 1896個の "unknown node type" 警告が発生
+3. **dogfooding不可**: typsphinx自身のAPIドキュメントをtypstpdfで生成できない
+4. **ユーザー体験の低下**: autodocを使用する一般的なSphinxプロジェクトでPDFが生成できない
+
+Issue #55で報告された通り、以下の15種類のノードタイプが未対応：
+
+**Core autodoc nodes (9種類):**
+- `index` - APIインデックスエントリ
+- `desc` - API説明コンテナ（class、method、attributeなど）
+- `desc_signature` - 関数/クラスシグネチャ
+- `desc_content` - 説明コンテンツ
+- `desc_annotation` - 型注釈（`class`キーワードなど）
+- `desc_addname` - モジュール名プレフィックス
+- `desc_name` - 関数/クラス名
+- `desc_parameterlist` - パラメータリスト
+- `desc_parameter` - 個別のパラメータ
+
+**Field list nodes (4種類):**
+- `field_list` - パラメータ/返り値ドキュメントのコンテナ
+- `field` - 個別のフィールド
+- `field_name` - フィールド名（"Parameters", "Returns"など）
+- `field_body` - フィールドコンテンツ
+
+**Additional nodes (2種類):**
+- `rubric` - APIドキュメント内のセクション見出し
+- `title_reference` - タイトル参照
+
+## What Changes
+
+### 1. translator.pyの拡張
+
+`typsphinx/translator.py`に以下のvisitor/departメソッドを追加：
+
+#### Index nodes
+- `visit_index()` / `depart_index()` - インデックスエントリをスキップ（Typstには不要）
+
+#### Desc nodes (API descriptions)
+- `visit_desc()` / `depart_desc()` - API説明ブロック全体のコンテナ
+- `visit_desc_signature()` / `depart_desc_signature()` - シグネチャ部分（関数名、パラメータなど）
+- `visit_desc_content()` / `depart_desc_content()` - 説明コンテンツ部分
+- `visit_desc_annotation()` / `depart_desc_annotation()` - 型注釈・キーワード
+- `visit_desc_addname()` / `depart_desc_addname()` - モジュール名プレフィックス
+- `visit_desc_name()` / `depart_desc_name()` - 関数/クラス名
+- `visit_desc_parameterlist()` / `depart_desc_parameterlist()` - パラメータリスト全体
+- `visit_desc_parameter()` / `depart_desc_parameter()` - 個別パラメータ
+
+#### Field list nodes
+- `visit_field_list()` / `depart_field_list()` - フィールドリスト全体
+- `visit_field()` / `depart_field()` - 個別フィールド
+- `visit_field_name()` / `depart_field_name()` - フィールド名
+- `visit_field_body()` / `depart_field_body()` - フィールドボディ
+
+#### Additional nodes
+- `visit_rubric()` / `depart_rubric()` - セクション見出し
+- `visit_title_reference()` / `depart_title_reference()` - タイトル参照
+
+### 2. Typst出力フォーマット
+
+autodocノードのTypst表現：
+
+- **クラス/関数シグネチャ**: `#strong[class TypstBuilder(app, env)]` 形式
+- **パラメータリスト**: シンプルなテキスト表現
+- **フィールドリスト**: 見出し（`*Parameters:*`）+ 箇条書きリスト
+- **index**: 出力なし（PDFではインデックスを生成しない）
+
+### 3. テストの追加
+
+- autodocノードのユニットテスト（各ノードタイプ）
+- 実際のAPIドキュメントビルドの統合テスト
+- Issue #55で特定された問題の回帰テスト
+
+## Impact
+
+### Affected specs
+
+既存specの修正：
+- `document-conversion`: autodocノードサポートを追加
+
+新規specの追加：
+- なし（既存capabilityの拡張）
+
+### Affected code
+
+変更ファイル：
+- `typsphinx/translator.py` - 30個の新しいvisitor/departメソッド（15ノードタイプ × 2）
+- `tests/test_autodoc_nodes.py` - 新規テストファイル
+- `tests/test_integration_autodoc.py` - 新規統合テストファイル
+
+### Breaking changes
+
+なし - 既存機能への影響なし、新機能の追加のみ
+
+### User-visible changes
+
+- ✅ autodocを使用するドキュメントのPDFビルドが成功
+- ✅ API referenceページがPDFに含まれる
+- ✅ typsphinx自身のドキュメントで完全なPDF生成が可能（dogfooding）
+- ✅ "unknown node type" 警告が消える
+
+## Alternatives Considered
+
+### 1. autodocノードを無視する（現状維持）
+- 問題: ユーザーはAPIドキュメントをPDFで生成できない
+- 問題: typsphinx自身のドキュメントが不完全
+
+### 2. HTMLのみサポート、PDFは諦める
+- 問題: PDFビルダー（typstpdf）の価値が大幅に低下
+- 問題: APIドキュメントが必要なプロジェクトでtypsphinxを使えない
+
+### 3. 段階的実装（基本ノードのみ）
+- メリット: より早くリリース可能
+- デメリット: 不完全なサポートで依然として警告が出る
+- **却下理由**: 15ノードタイプは相互依存しており、部分実装では効果が薄い
+
+### 4. すべてのautodocノードを実装（選択）
+- **メリット**: 完全なサポート、警告ゼロ、dogfooding可能
+- **メリット**: 一般的なSphinxプロジェクトで広く使える
+- **実装コスト**: 合理的（30メソッド、既存パターンに従う）
+
+## Implementation Notes
+
+### 実装方針
+
+1. **シンプルさ優先**: 複雑なTypst書式設定より、読みやすさを重視
+2. **既存パターン踏襲**: 他のノードと同じvisitor/departパターン
+3. **段階的テスト**: ノードタイプごとにテストを追加
+
+### Typst出力例
+
+```typst
+// Class signature
+#strong[class TypstBuilder(app, env)]
+
+Base class: Builder
+
+Builder class for Typst output format.
+
+*Parameters:*
+- *app* (Sphinx) – Sphinx application
+- *env* (BuildEnvironment) – Build environment
+
+*Methods:*
+
+#strong[init()]
+
+Initialize the builder.
+
+*Return type:* None
+```
+
+### 技術的考慮事項
+
+- **ネスト構造**: desc_content内にfield_listがネストされる構造を正しく処理
+- **空ノード**: 空のdesc_annotationなどを適切にスキップ
+- **エスケープ**: Typst特殊文字のエスケープ処理

--- a/openspec/changes/add-autodoc-node-support/specs/document-conversion/spec.md
+++ b/openspec/changes/add-autodoc-node-support/specs/document-conversion/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: API説明ノードの処理
+
+docutilsの`desc`ノードファミリー（API説明用の汎用ノード）、`field_list`ノード（構造化フィールド）、`index`ノード（索引エントリー）、`rubric`ノード（小見出し）、`title_reference`ノード（タイトル参照）を適切に処理し、Typst形式に変換しなければならない (MUST)。これらのノードはsphinx.ext.autodocなど複数の拡張で使用される汎用ノードである。
+
+#### Scenario: インデックスノードのスキップ
+
+- **GIVEN** `index`ノード（索引エントリー）が含まれる
+- **WHEN** Typst形式に変換される
+- **THEN** `index`ノードは出力に含まれない（PDFではインデックスを生成しない）
+- **AND** "unknown node type: index" 警告が表示されない
+
+#### Scenario: API説明ブロックの変換
+
+- **GIVEN** `desc`ノード（API説明用コンテナ）が含まれる
+- **WHEN** Typst形式に変換される
+- **THEN** `desc`ノードが適切なTypst構造として出力される
+- **AND** ネストされた`desc_signature`と`desc_content`が正しく処理される
+- **AND** "unknown node type: desc" 警告が表示されない
+
+#### Scenario: 関数/クラスシグネチャの書式設定
+
+- **GIVEN** `desc_signature`ノード（API要素のシグネチャ）が含まれる
+  ```python
+  class TypstBuilder(app, env):
+      ...
+  ```
+- **WHEN** Typst形式に変換される
+- **THEN** シグネチャが`#strong[class TypstBuilder(app, env)]`形式で出力される
+- **AND** `desc_annotation`（"class"キーワード）、`desc_name`（クラス名）、`desc_parameterlist`（パラメータ）がすべて正しく結合される
+- **AND** 関連する警告が表示されない
+
+#### Scenario: パラメータリストの処理
+
+- **GIVEN** `desc_parameterlist`と複数の`desc_parameter`ノードが含まれる
+  ```python
+  def example(arg1, arg2, arg3):
+      ...
+  ```
+- **WHEN** Typst形式に変換される
+- **THEN** パラメータが`(arg1, arg2, arg3)`形式で出力される
+- **AND** パラメータ間のカンマと括弧が正しく処理される
+- **AND** "unknown node type: desc_parameter" 警告が表示されない
+
+#### Scenario: モジュール名プレフィックスの処理
+
+- **GIVEN** `desc_addname`ノード（モジュール名プレフィックス）が含まれる
+  ```python
+  typsphinx.builder.TypstBuilder
+  ```
+- **WHEN** Typst形式に変換される
+- **THEN** モジュール名プレフィックスが出力に含まれる
+- **AND** クラス名との結合が正しく行われる
+- **AND** "unknown node type: desc_addname" 警告が表示されない
+
+#### Scenario: フィールドリストの変換
+
+- **GIVEN** `field_list`ノード（構造化フィールド、Parameters・Returnsなど）が含まれる
+  ```rst
+  :param app: Sphinx application
+  :param env: Build environment
+  :return: None
+  ```
+- **WHEN** Typst形式に変換される
+- **THEN** フィールドリストが適切な見出しと箇条書きリストとして出力される
+  ```typst
+  *Parameters:*
+  - *app* (Sphinx) – Sphinx application
+  - *env* (BuildEnvironment) – Build environment
+
+  *Returns:* None
+  ```
+- **AND** "unknown node type: field_list" 警告が表示されない
+
+#### Scenario: フィールド名とボディの処理
+
+- **GIVEN** `field_name`と`field_body`ノードが含まれる
+- **WHEN** Typst形式に変換される
+- **THEN** フィールド名が強調表示される（例: `*Parameters:*`）
+- **AND** フィールドボディが適切にフォーマットされる
+- **AND** 関連する警告が表示されない
+
+#### Scenario: Rubricノードの処理
+
+- **GIVEN** `rubric`ノード（セクション小見出し）が含まれる
+- **WHEN** Typst形式に変換される
+- **THEN** rubricが適切な見出しとして出力される
+- **AND** "unknown node type: rubric" 警告が表示されない
+
+#### Scenario: タイトル参照の処理
+
+- **GIVEN** `title_reference`ノードが含まれる
+- **WHEN** Typst形式に変換される
+- **THEN** タイトル参照が適切にフォーマットされる
+- **AND** "unknown node type: title_reference" 警告が表示されない
+
+#### Scenario: ネストされたAPI説明ノード構造
+
+- **GIVEN** 複雑にネストされたdescノード構造が含まれる
+  ```
+  desc
+    desc_signature
+      desc_annotation: "class"
+      desc_addname: "typsphinx.builder."
+      desc_name: "TypstBuilder"
+      desc_parameterlist
+        desc_parameter: "app"
+        desc_parameter: "env"
+    desc_content
+      paragraph: "Builder class for Typst output format."
+      field_list
+        field
+          field_name: "Parameters"
+          field_body: ...
+  ```
+- **WHEN** Typst形式に変換される
+- **THEN** すべてのネストレベルが正しく処理される
+- **AND** 親子関係が維持される
+- **AND** すべてのAPI説明ノードタイプについて警告が表示されない
+
+#### Scenario: 完全なAPIドキュメントのPDFビルド
+
+- **GIVEN** sphinx.ext.autodoc、sphinx.ext.napoleon、sphinx_autodoc_typehintsを使用したAPIドキュメント
+- **WHEN** `typstpdf`ビルダーでPDFを生成する
+- **THEN** PDFビルドが成功する
+- **AND** すべてのAPIドキュメント（クラス、メソッド、関数、属性）がPDFに含まれる
+- **AND** API説明ノード関連の "unknown node type" 警告が0件である
+- **AND** 生成されたPDFが読みやすい形式でフォーマットされている
+
+#### Scenario: typsphinx自身のドキュメントでのdogfooding
+
+- **GIVEN** typsphinxプロジェクトのAPIドキュメント（`docs/source/api/`）
+- **WHEN** `uv run tox -e docs-pdf`でPDFビルドを実行する
+- **THEN** ビルドが警告なしで成功する
+- **AND** 生成されたPDFにtypsphinxのすべてのモジュール、クラス、関数のドキュメントが含まれる
+- **AND** Issue #55で報告された1896件の警告が発生しない

--- a/openspec/changes/add-autodoc-node-support/tasks.md
+++ b/openspec/changes/add-autodoc-node-support/tasks.md
@@ -1,0 +1,65 @@
+# Implementation Tasks: Add Autodoc Node Support
+
+## 1. Index Node Support
+
+- [x] **Implement visit_index() method** - Add to translator.py to skip index nodes (Typst doesn't need index entries)
+- [x] **Implement depart_index() method** - Add to translator.py
+- [x] **Test index node handling** - Add unit test in tests/test_translator.py
+
+## 2. Desc Nodes Support (API Descriptions)
+
+- [x] **Implement visit_desc() method** - Add container for API description blocks
+- [x] **Implement depart_desc() method** - Close API description blocks
+- [x] **Implement visit_desc_signature() method** - Format function/class signatures
+- [x] **Implement depart_desc_signature() method** - Close signature blocks
+- [x] **Implement visit_desc_content() method** - Handle description content
+- [x] **Implement depart_desc_content() method** - Close content blocks
+- [x] **Implement visit_desc_annotation() method** - Format type annotations (e.g., "class" keyword)
+- [x] **Implement depart_desc_annotation() method** - Close annotations
+- [x] **Implement visit_desc_addname() method** - Handle module name prefixes
+- [x] **Implement depart_desc_addname() method** - Close addname
+- [x] **Implement visit_desc_name() method** - Format function/class names
+- [x] **Implement depart_desc_name() method** - Close name
+- [x] **Implement visit_desc_parameterlist() method** - Start parameter list
+- [x] **Implement depart_desc_parameterlist() method** - Close parameter list
+- [x] **Implement visit_desc_parameter() method** - Format individual parameters
+- [x] **Implement depart_desc_parameter() method** - Close parameter
+- [x] **Test desc node family** - Add comprehensive tests for all desc nodes
+- [x] **Implement desc_sig_* nodes** - Added visit/depart methods for desc_sig_keyword, desc_sig_space, desc_sig_name, desc_sig_punctuation, desc_sig_operator
+
+## 3. Field List Nodes Support
+
+- [x] **Implement visit_field_list() method** - Start field list container
+- [x] **Implement depart_field_list() method** - Close field list
+- [x] **Implement visit_field() method** - Handle individual fields
+- [x] **Implement depart_field() method** - Close field
+- [x] **Implement visit_field_name() method** - Format field names (e.g., "Parameters:", "Returns:")
+- [x] **Implement depart_field_name() method** - Close field name
+- [x] **Implement visit_field_body() method** - Handle field content
+- [x] **Implement depart_field_body() method** - Close field body
+- [x] **Test field list nodes** - Add tests for field list rendering
+
+## 4. Additional Nodes Support
+
+- [x] **Implement visit_rubric() method** - Format section headings in API docs
+- [x] **Implement depart_rubric() method** - Close rubric
+- [x] **Implement visit_title_reference() method** - Handle title references
+- [x] **Implement depart_title_reference() method** - Close title reference
+- [x] **Test additional nodes** - Add tests for rubric and title_reference
+- [x] **Implement literal_strong/literal_emphasis** - Added visit/depart methods for literal formatting in field lists
+
+## 5. Integration Testing
+
+- [x] **Create integration test fixture** - Added unit tests in tests/test_translator.py
+- [x] **Test full API documentation build** - Full test in test_full_api_description_structure
+- [x] **Verify no warnings** - Confirmed "unknown node type" warnings eliminated (0 autodoc warnings)
+- [x] **Regression test for Issue #55** - Verified with `uv run tox -e docs-pdf` - no autodoc node warnings
+
+## 6. Validation and Quality
+
+- [x] **Run pytest** - All 85 tests pass with `uv run pytest tests/test_translator.py`
+- [x] **Run mypy** - Type-check passed: `Success: no issues found in 1 source file`
+- [x] **Run black** - Code formatted: `2 files left unchanged`
+- [x] **Run ruff** - Lint passed after fixing import order
+- [x] **Build typsphinx docs as PDF** - Build succeeded with 0 "unknown node type" warnings for autodoc nodes
+- [x] **Verify spec compliance** - `openspec validate add-autodoc-node-support --strict` passed

--- a/typsphinx/translator.py
+++ b/typsphinx/translator.py
@@ -1644,3 +1644,249 @@ class TypstTranslator(SphinxTranslator):
         Depart an inline node.
         """
         pass
+
+    # API description nodes (Issue #55)
+    # Requirement: API説明ノードの処理
+
+    def visit_index(self, node: addnodes.index) -> None:
+        """
+        Visit an index node.
+
+        Index entries are skipped in Typst/PDF output as we don't generate indices.
+        """
+        raise nodes.SkipNode
+
+    def depart_index(self, node: addnodes.index) -> None:
+        """Depart an index node."""
+        pass
+
+    def visit_desc(self, node: addnodes.desc) -> None:
+        """
+        Visit a desc node (API description container).
+
+        Desc nodes contain API descriptions (classes, functions, methods, etc.).
+        """
+        pass
+
+    def depart_desc(self, node: addnodes.desc) -> None:
+        """
+        Depart a desc node.
+
+        Add spacing after API description blocks.
+        """
+        self.body.append("\n\n")
+
+    def visit_desc_signature(self, node: addnodes.desc_signature) -> None:
+        """
+        Visit a desc_signature node (API element signature).
+
+        Signatures are rendered in bold.
+        """
+        self.body.append("#strong[")
+
+    def depart_desc_signature(self, node: addnodes.desc_signature) -> None:
+        """Depart a desc_signature node."""
+        self.body.append("]\n\n")
+
+    def visit_desc_content(self, node: addnodes.desc_content) -> None:
+        """
+        Visit a desc_content node (API description content).
+        """
+        pass
+
+    def depart_desc_content(self, node: addnodes.desc_content) -> None:
+        """Depart a desc_content node."""
+        pass
+
+    def visit_desc_annotation(self, node: addnodes.desc_annotation) -> None:
+        """
+        Visit a desc_annotation node (type annotations like 'class', 'async', etc.).
+        """
+        pass
+
+    def depart_desc_annotation(self, node: addnodes.desc_annotation) -> None:
+        """
+        Depart a desc_annotation node.
+
+        Add space after annotation keywords.
+        """
+        self.body.append(" ")
+
+    def visit_desc_addname(self, node: addnodes.desc_addname) -> None:
+        """
+        Visit a desc_addname node (module name prefix).
+        """
+        pass
+
+    def depart_desc_addname(self, node: addnodes.desc_addname) -> None:
+        """Depart a desc_addname node."""
+        pass
+
+    def visit_desc_name(self, node: addnodes.desc_name) -> None:
+        """
+        Visit a desc_name node (function/class name).
+        """
+        pass
+
+    def depart_desc_name(self, node: addnodes.desc_name) -> None:
+        """Depart a desc_name node."""
+        pass
+
+    def visit_desc_parameterlist(self, node: addnodes.desc_parameterlist) -> None:
+        """
+        Visit a desc_parameterlist node (parameter list container).
+        """
+        self.body.append("(")
+
+    def depart_desc_parameterlist(self, node: addnodes.desc_parameterlist) -> None:
+        """Depart a desc_parameterlist node."""
+        self.body.append(")")
+
+    def visit_desc_parameter(self, node: addnodes.desc_parameter) -> None:
+        """
+        Visit a desc_parameter node (individual parameter).
+        """
+        pass
+
+    def depart_desc_parameter(self, node: addnodes.desc_parameter) -> None:
+        """
+        Depart a desc_parameter node.
+
+        Add comma and space between parameters, except for the last one.
+        """
+        if node.next_node(descend=False, siblings=True):
+            self.body.append(", ")
+
+    def visit_field_list(self, node: nodes.field_list) -> None:
+        """
+        Visit a field_list node (structured fields like Parameters, Returns).
+        """
+        pass
+
+    def depart_field_list(self, node: nodes.field_list) -> None:
+        """
+        Depart a field_list node.
+
+        Add spacing after field lists.
+        """
+        self.body.append("\n")
+
+    def visit_field(self, node: nodes.field) -> None:
+        """
+        Visit a field node (individual field in a field list).
+        """
+        pass
+
+    def depart_field(self, node: nodes.field) -> None:
+        """Depart a field node."""
+        pass
+
+    def visit_field_name(self, node: nodes.field_name) -> None:
+        """
+        Visit a field_name node (field name like 'Parameters', 'Returns').
+
+        Field names are rendered in bold with a colon.
+        """
+        self.body.append("*")
+
+    def depart_field_name(self, node: nodes.field_name) -> None:
+        """Depart a field_name node."""
+        self.body.append(":*\n")
+
+    def visit_field_body(self, node: nodes.field_body) -> None:
+        """
+        Visit a field_body node (field content).
+        """
+        pass
+
+    def depart_field_body(self, node: nodes.field_body) -> None:
+        """
+        Depart a field_body node.
+
+        Add newline after field body.
+        """
+        self.body.append("\n")
+
+    def visit_rubric(self, node: nodes.rubric) -> None:
+        """
+        Visit a rubric node (section subheading).
+
+        Rubrics are rendered as subsection headings.
+        """
+        self.body.append("\n#strong[")
+
+    def depart_rubric(self, node: nodes.rubric) -> None:
+        """Depart a rubric node."""
+        self.body.append("]\n\n")
+
+    def visit_title_reference(self, node: nodes.title_reference) -> None:
+        """
+        Visit a title_reference node (reference to a title).
+
+        Title references are rendered in emphasis.
+        """
+        self.body.append("#emph[")
+
+    def depart_title_reference(self, node: nodes.title_reference) -> None:
+        """Depart a title_reference node."""
+        self.body.append("]")
+
+    # Additional signature nodes (desc_sig_* family)
+
+    def visit_desc_sig_keyword(self, node: addnodes.desc_sig_keyword) -> None:
+        """Visit a desc_sig_keyword node (keywords in signatures like 'class', 'def')."""
+        pass
+
+    def depart_desc_sig_keyword(self, node: addnodes.desc_sig_keyword) -> None:
+        """Depart a desc_sig_keyword node."""
+        pass
+
+    def visit_desc_sig_space(self, node: addnodes.desc_sig_space) -> None:
+        """Visit a desc_sig_space node (whitespace in signatures)."""
+        pass
+
+    def depart_desc_sig_space(self, node: addnodes.desc_sig_space) -> None:
+        """Depart a desc_sig_space node."""
+        pass
+
+    def visit_desc_sig_name(self, node: addnodes.desc_sig_name) -> None:
+        """Visit a desc_sig_name node (names in signatures)."""
+        pass
+
+    def depart_desc_sig_name(self, node: addnodes.desc_sig_name) -> None:
+        """Depart a desc_sig_name node."""
+        pass
+
+    def visit_desc_sig_punctuation(self, node: addnodes.desc_sig_punctuation) -> None:
+        """Visit a desc_sig_punctuation node (punctuation in signatures like ':', '=')."""
+        pass
+
+    def depart_desc_sig_punctuation(self, node: addnodes.desc_sig_punctuation) -> None:
+        """Depart a desc_sig_punctuation node."""
+        pass
+
+    def visit_desc_sig_operator(self, node: addnodes.desc_sig_operator) -> None:
+        """Visit a desc_sig_operator node (operators in signatures)."""
+        pass
+
+    def depart_desc_sig_operator(self, node: addnodes.desc_sig_operator) -> None:
+        """Depart a desc_sig_operator node."""
+        pass
+
+    # Literal nodes for API documentation
+
+    def visit_literal_strong(self, node: nodes.inline) -> None:
+        """Visit a literal_strong node (bold literal text in field lists)."""
+        self.body.append("#strong[")
+
+    def depart_literal_strong(self, node: nodes.inline) -> None:
+        """Depart a literal_strong node."""
+        self.body.append("]")
+
+    def visit_literal_emphasis(self, node: nodes.inline) -> None:
+        """Visit a literal_emphasis node (emphasized literal text in field lists)."""
+        self.body.append("#emph[")
+
+    def depart_literal_emphasis(self, node: nodes.inline) -> None:
+        """Depart a literal_emphasis node."""
+        self.body.append("]")


### PR DESCRIPTION
## Summary

Add comprehensive support for Sphinx autodoc-generated nodes to enable PDF generation of API documentation.

Resolves #55

## Changes

### Core Implementation
- **typsphinx/translator.py**: Added 44 new visitor/depart methods for API description nodes
  - Core nodes (9): index, desc, desc_signature, desc_content, desc_annotation, desc_addname, desc_name, desc_parameterlist, desc_parameter
  - Signature detail nodes (5): desc_sig_keyword, desc_sig_space, desc_sig_name, desc_sig_punctuation, desc_sig_operator
  - Field list nodes (4): field_list, field, field_name, field_body
  - Additional nodes (4): rubric, title_reference, literal_strong, literal_emphasis

### Tests
- **tests/test_translator.py**: Added 9 comprehensive test cases
  - Individual node type tests
  - Complete nested structure tests
  - Typst output format verification

### OpenSpec Documentation
- **openspec/changes/add-autodoc-node-support/**: Complete change proposal with tasks and spec deltas

## Impact

✅ **Eliminates all 1896 "unknown node type" warnings** for autodoc nodes  
✅ **Enables PDF generation** for API documentation  
✅ **Dogfooding**: typsphinx can now generate its own API docs as PDF  
✅ **No breaking changes** to existing functionality  

## Test Results

```
✅ All 85 tests pass (uv run pytest tests/test_translator.py)
✅ mypy type checking: Success: no issues found
✅ black/ruff formatting: pass
✅ PDF build: 0 autodoc-related warnings (previously 1896)
```

## Example Output

**Generated Typst** (from API documentation):
```typst
#strong[class typsphinx.builder.TypstBuilder(app, env)]

Bases: Builder

Builder class for Typst output format.

*Parameters:*
- #strong[app] (#emph[Sphinx]) – Sphinx application
- #strong[env] (#emph[BuildEnvironment]) – Build environment
```

## Implementation Notes

- Follows existing visitor/depart pattern for consistency
- Uses simple pass-through for transparent container nodes
- Formats API elements using Typst strong/emphasis functions
- Field lists rendered as bold field names with structured content

🤖 Generated with [Claude Code](https://claude.com/claude-code)