### PR TITLE
docs: Archive OpenSpec change fix-table-cell-unified-code-mode

### DIFF
--- a/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/proposal.md
+++ b/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/proposal.md
@@ -1,0 +1,165 @@
+# Proposal: Fix Table Cell Unified Code Mode Compliance
+
+## Status
+- **State**: Draft
+- **Related Spec**: table-rendering
+- **Breaking Change**: No (output change only, API unchanged)
+- **Created**: 2025-10-26
+
+## Summary
+
+現在のtableセル生成が Unified Code Mode 指針に違反しています。マークアップモード `[...]` を使用せず、content型を直接渡すように修正します。
+
+### Current Behavior
+
+```typst
+#{
+  table(
+    columns: 2,
+    [par({text("Cell 1")})],              # マークアップモード内で#なし → 指針違反
+    table.cell(colspan: 2)[content],      # 引数順序が間違い
+  )
+}
+```
+
+### Expected Behavior
+
+```typst
+#{
+  table(
+    columns: 2,
+    par({text("Cell 1")}),                # content型を直接渡す
+    table.cell(par({text("Spans")}), colspan: 2),  # content型を第1引数に
+  )
+}
+```
+
+## Why
+
+### Unified Code Mode Compliance
+
+[openspec/changes/archive/2025-10-25-unified-function-approach/proposal.md](../archive/2025-10-25-unified-function-approach/proposal.md) で定義された指針：
+
+1. **ドキュメント全体を `#{...}` で囲む**
+2. **コードモード内では関数名に `#` を付けない**
+3. **マークアップモード `[...]` 内では関数名に `#` を付ける**
+4. **できるだけ `text()` 関数を使い、マークアップモードを避ける**
+
+### Current Problems
+
+1. **マークアップモードの不要な使用**
+   - tableセルで `[content]` を使用
+   - Unified Code Mode指針の「マークアップモードを避ける」に反する
+
+2. **マークアップモード内での `#` 省略**
+   - `[par({text(...)})]` のように `#` なしで関数を呼び出し
+   - 指針の「マークアップモード内では `#` を付ける」に反する
+
+3. **`table.cell()` の引数順序が間違い**
+   - 現在: `table.cell(colspan: 2)[content]`
+   - 正しい: `table.cell(content, colspan: 2)`
+   - Typst公式: 第1引数がcontent型のbody
+
+### Benefits
+
+1. **完全な一貫性**
+   - すべてのTypst要素がUnified Code Mode指針に従う
+   - マークアップモードを使わず、content型を直接渡す
+
+2. **正しい構文**
+   - `table.cell()` の引数順序がTypst公式と一致
+   - より読みやすく、予測可能なコード
+
+3. **保守性の向上**
+   - 一貫したパターンで新機能の追加が容易
+   - デバッグとテストが簡単
+
+## What
+
+### Changes
+
+#### 1. `_format_table_cell()` Method
+
+**File**: `typsphinx/translator.py:1201-1228`
+
+**Normal cells (no colspan/rowspan)**:
+```python
+# Before
+return f"{indent}[{content}],\n"
+
+# After
+return f"{indent}{content},\n"
+```
+
+**Spanning cells**:
+```python
+# Before
+return f"{indent}table.cell({params_str})[{content}],\n"
+
+# After
+return f"{indent}table.cell({content}, {params_str}),\n"
+```
+
+### Affected Components
+
+- `typsphinx/translator.py`: `_format_table_cell()` method only
+- Tests: 10 table tests (validation only, no changes needed)
+
+### Migration Path
+
+なし。出力形式の変更のみで、APIは変更なし。既存のSphinxドキュメントは再ビルドで自動的に新しい形式で生成される。
+
+## Validation
+
+### Test Strategy
+
+1. **既存テストの実行**
+   - 10個のtableテスト全てがパス
+   - テスト自体は文字列含有チェックのみなので変更不要
+
+2. **Typst構文検証**
+   - 生成されたTypstファイルがコンパイル可能
+   - PDFが正しく生成される
+
+3. **統合テスト**
+   - ドキュメントビルドが成功
+   - table-renderingの全シナリオが動作
+
+### Success Criteria
+
+- ✅ すべてのtableテストがパス
+- ✅ Typstファイルがエラーなくコンパイル
+- ✅ ドキュメントPDFが正しく生成
+- ✅ Unified Code Mode指針に完全準拠
+
+## Dependencies
+
+なし。独立した変更。
+
+## Alternatives Considered
+
+### Alternative 1: マークアップモード内で `#` を付ける
+
+```typst
+#{
+  table(
+    columns: 2,
+    [#par({text("Cell 1")})],  # マークアップモード内で#を付ける
+  )
+}
+```
+
+**却下理由**:
+- Unified Code Mode指針の「マークアップモードを避ける」に反する
+- 不要な複雑さを導入
+
+### Alternative 2: 現状維持
+
+**却下理由**:
+- Unified Code Mode指針に違反し続ける
+- 不一貫な実装パターンが残る
+- 将来的なメンテナンスコストが高い
+
+## Implementation Plan
+
+See [tasks.md](./tasks.md) for detailed implementation tasks.

--- a/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/specs/table-rendering/spec.md
+++ b/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/specs/table-rendering/spec.md
@@ -1,0 +1,105 @@
+# Spec Delta: table-rendering
+
+## MODIFIED Requirements
+
+### Requirement: セル結合のサポート
+
+テーブルセルの水平結合（colspan）と垂直結合（rowspan）をサポートしなければならない (MUST)。docutilsの`morecols`と`morerows`属性を読み取り、Typstの`table.cell()`構文に変換する。
+
+#### Scenario: 水平結合セルの変換
+
+- **GIVEN** `morecols=1`属性を持つテーブルセル（2列分）
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.cell(content, colspan: 2)`を含む
+- **AND** 通常セルは`content`として出力される（マークアップモード `[...]` なし）
+
+**変更理由**: Unified Code Mode指針に従い、マークアップモード `[...]` を使用せず、content型を直接渡す。`table.cell()`の第1引数はcontent型のbody。
+
+#### Scenario: 垂直結合セルの変換
+
+- **GIVEN** `morerows=1`属性を持つテーブルセル（2行分）
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.cell(content, rowspan: 2)`を含む
+
+**変更理由**: `table.cell()`の引数順序を修正（content型を第1引数に）。
+
+#### Scenario: 複合結合セルの変換
+
+- **GIVEN** `morecols=1`と`morerows=1`属性を持つテーブルセル
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.cell(content, colspan: 2, rowspan: 2)`を含む
+
+**変更理由**: `table.cell()`の引数順序を修正。
+
+#### Scenario: ヘッダー内の結合セルの変換
+
+- **GIVEN** `thead`内に`morecols=1`属性を持つヘッダーセル
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.header(table.cell(content, colspan: 2), ...)`を含む
+- **AND** ヘッダーセルと結合セルの両方の機能が正しく動作する
+
+**変更理由**: `table.cell()`の引数順序を修正し、マークアップモードを削除。
+
+#### Scenario: 複数の結合セルを持つテーブル
+
+- **GIVEN** 同一テーブル内に複数の結合セルが存在する
+- **WHEN** Typst形式に変換する
+- **THEN** すべての結合セルが正しく`table.cell(content, ...)`でラップされる
+- **AND** 通常セルは`content`として出力される（マークアップモードなし）
+
+**変更理由**: 一貫性のため、すべてのセルでマークアップモードを削除。
+
+#### Scenario: 結合のないテーブル（後方互換性）
+
+- **GIVEN** `morecols`も`morerows`も持たないテーブル
+- **WHEN** Typst形式に変換する
+- **THEN** すべてのセルは`content`として出力される（マークアップモード `[...]` なし）
+- **AND** `table.cell()`は生成されない（既存の動作を維持）
+
+**変更理由**: Unified Code Mode指針に従い、マークアップモードを削除。
+
+## ADDED Requirements
+
+### Requirement: Unified Code Mode準拠のセル出力
+
+テーブルセルの出力は、Unified Code Mode指針に従い、マークアップモード `[...]` を使用せず、content型を直接渡さなければならない (MUST)。
+
+#### Scenario: 通常セルのcontent型出力
+
+- **GIVEN** colspan/rowspanを持たない通常のテーブルセル
+- **AND** セル内容が`par({text("Cell 1")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`par({text("Cell 1")}),`を含む
+- **AND** マークアップモード `[...]` でラップされない
+
+**理由**: Unified Code Mode指針の「マークアップモードを避ける」に従う。
+
+#### Scenario: spanningセルのcontent型第1引数
+
+- **GIVEN** `morecols=1`を持つセル
+- **AND** セル内容が`par({text("Spans 2 cols")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.cell(par({text("Spans 2 cols")}), colspan: 2),`を含む
+- **AND** content型が第1引数として渡される
+
+**理由**: Typst公式の`table.cell(body, colspan: 1, rowspan: 1)`シグネチャに従う。
+
+#### Scenario: ヘッダーセルのcontent型出力
+
+- **GIVEN** `thead`内のヘッダーセル
+- **AND** セル内容が`par({text("Header")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.header(par({text("Header")}), ...)`を含む
+- **AND** マークアップモード `[...]` でラップされない
+
+**理由**: ヘッダーセルも通常セルと同様にUnified Code Mode指針に従う。
+
+#### Scenario: 複雑な内容のセル出力
+
+- **GIVEN** 複数の要素を含むセル（例: `text("A") + strong({text("B")})`）
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`text("A") + strong({text("B")}),`を含む
+- **AND** マークアップモードでラップされない
+- **AND** content型の式が直接渡される
+
+**理由**: 任意のcontent型式を直接渡せることを保証。

--- a/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/tasks.md
+++ b/openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/tasks.md
@@ -1,0 +1,210 @@
+# Tasks: fix-table-cell-unified-code-mode
+
+## Overview
+
+tableセル生成をUnified Code Mode指針に準拠させる。マークアップモード `[...]` を削除し、content型を直接渡すように修正する。
+
+## Task List
+
+### 1. Create feature branch
+- [x] Create branch `fix/table-cell-unified-code-mode` from `main`
+- [x] Verify branch is clean and up-to-date
+
+**Validation**: `git status` shows clean working directory
+
+---
+
+### 2. Modify `_format_table_cell()` - Normal cells
+- [x] Update `typsphinx/translator.py:1218`
+- [x] Change `return f"{indent}[{content}],\n"` to `return f"{indent}{content},\n"`
+- [x] Remove markdown wrapping `[...]` from normal cells (already done in previous work)
+
+**File**: `typsphinx/translator.py`
+**Location**: Line 1218 (in the `if colspan == 1 and rowspan == 1:` block)
+
+**Before**:
+```python
+# Normal cell (no spanning)
+if colspan == 1 and rowspan == 1:
+    return f"{indent}[{content}],\n"
+```
+
+**After**:
+```python
+# Normal cell (no spanning)
+if colspan == 1 and rowspan == 1:
+    return f"{indent}{content},\n"
+```
+
+**Validation**: Code review - verify syntax is correct
+
+---
+
+### 3. Modify `_format_table_cell()` - Spanning cells
+- [x] Update `typsphinx/translator.py:1228`
+- [x] Change `return f"{indent}table.cell({params_str})[{content}],\n"` to `return f"{indent}table.cell({content}, {params_str}),\n"`
+- [x] Fix argument order: content as first positional argument
+- [x] Remove markdown wrapping `[...]`
+
+**File**: `typsphinx/translator.py`
+**Location**: Line 1228 (in the spanning cell block)
+
+**Before**:
+```python
+params_str = ", ".join(params)
+return f"{indent}table.cell({params_str})[{content}],\n"
+```
+
+**After**:
+```python
+params_str = ", ".join(params)
+return f"{indent}table.cell({content}, {params_str}),\n"
+```
+
+**Validation**: Code review - verify argument order matches Typst signature
+
+---
+
+### 4. Run all table tests
+- [x] Execute `uv run pytest tests/test_translator.py -k table -v`
+- [x] Verify all 11 table tests pass (updated test assertions for new syntax)
+- [x] Review test output for any unexpected failures
+
+**Expected**: All 10 tests pass without modifications
+
+**Tests**:
+- `test_table_conversion`
+- `test_table_no_duplication_all_types`
+- `test_table_header_wrapping`
+- `test_table_without_header`
+- `test_table_multi_row_header`
+- `test_table_cell_colspan`
+- `test_table_cell_rowspan`
+- `test_table_cell_colspan_and_rowspan`
+- `test_table_header_cell_with_colspan`
+- `test_table_normal_cells_without_spanning`
+
+**Validation**: All tests green in pytest output
+
+---
+
+### 5. Verify Typst syntax with manual test
+- [x] Create test Typst file with new syntax
+- [x] Compile with `typst compile` to verify syntax
+- [x] Compare output with old syntax
+
+**Test file** (`/tmp/test-new-table-syntax.typ`):
+```typst
+#{
+  // Normal cells without markup mode
+  table(
+    columns: 2,
+    par({text("Cell 1")}),
+    par({text("Cell 2")}),
+  )
+
+  // Spanning cells with content as first argument
+  table(
+    columns: 3,
+    table.cell(par({text("Spans 2 cols")}), colspan: 2),
+    par({text("Col 3")}),
+  )
+}
+```
+
+**Validation**: `typst compile /tmp/test-new-table-syntax.typ /tmp/output.pdf` succeeds
+
+---
+
+### 6. Build documentation with new syntax
+- [x] Build Typst output: `uv run tox -e docs` (builds both HTML and PDF)
+- [x] Build PDF: `uv run tox -e docs` (included in docs target)
+- [x] Verify no compilation errors
+- [x] Inspect generated table in `docs/_build/pdf/user_guide/builders.typ`
+
+**Validation**:
+- Build succeeds
+- Generated Typst uses new syntax (no `[...]` around table cells)
+- PDF renders correctly
+
+---
+
+### 7. Run full test suite
+- [x] Execute `uv run pytest`
+- [x] Verify all 375 tests pass
+- [x] Check coverage remains ≥91%
+
+**Validation**:
+- Test output: `375 passed`
+- Coverage: `TOTAL ... 91%`
+
+---
+
+### 8. Code quality checks
+- [x] Run formatter: `uv run black typsphinx/translator.py tests/test_translator.py`
+- [x] Run linter: `uv run ruff check typsphinx/translator.py tests/test_translator.py`
+- [x] Run type checker: `uv run mypy typsphinx/translator.py`
+
+**Validation**: All checks pass with no errors
+
+---
+
+### 9. Commit changes
+- [x] Stage changes: `git add typsphinx/translator.py tests/test_translator.py`
+- [x] Commit with message:
+
+```
+fix: table cells use content type directly without markup mode
+
+Remove `[...]` markup mode wrapping from table cells to comply with
+Unified Code Mode guideline. Table cells now pass content type directly.
+
+Changes:
+- Normal cells: `[{content}]` → `{content}`
+- Spanning cells: `table.cell({params})[{content}]` → `table.cell({content}, {params})`
+
+This fixes the argument order for table.cell() to match Typst signature
+(content as first positional argument) and removes unnecessary markup mode.
+
+Refs: openspec/changes/fix-table-cell-unified-code-mode
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+**Validation**: `git log -1` shows commit
+
+---
+
+### 10. Push and create PR
+- [x] Push branch: `git push origin fix/table-cell-unified-code-mode`
+- [x] Create PR to `main` with description from proposal
+- [x] Link to OpenSpec change in PR description
+
+**PR URL**: https://github.com/YuSabo90002/typsphinx/pull/65
+
+**PR Title**: `Fix: Table cells comply with Unified Code Mode`
+
+**PR Description**: See `openspec/changes/fix-table-cell-unified-code-mode/proposal.md`
+
+**Validation**: PR created on GitHub
+
+---
+
+## Dependencies
+
+None. This is an isolated change to table cell formatting.
+
+## Parallel Work
+
+None. All tasks must be completed sequentially.
+
+## Success Criteria
+
+- ✅ All 375 tests pass
+- ✅ Code quality checks pass (black, ruff, mypy)
+- ✅ Documentation builds successfully
+- ✅ Generated Typst files use new syntax (no `[...]` around cells)
+- ✅ PDF output is correct
+- ✅ Unified Code Mode compliance achieved

--- a/openspec/specs/table-rendering/spec.md
+++ b/openspec/specs/table-rendering/spec.md
@@ -214,41 +214,53 @@ translatorは、現在処理中のセルがテーブルヘッダー（`thead`）
 
 - **GIVEN** `morecols=1`属性を持つテーブルセル（2列分）
 - **WHEN** Typst形式に変換する
-- **THEN** 出力は`table.cell(colspan: 2)[content]`を含む
-- **AND** 通常セルは`[content]`として出力される
+- **THEN** 出力は`table.cell(content, colspan: 2)`を含む
+- **AND** 通常セルは`content`として出力される（マークアップモード `[...]` なし）
+
+**変更理由**: Unified Code Mode指針に従い、マークアップモード `[...]` を使用せず、content型を直接渡す。`table.cell()`の第1引数はcontent型のbody。
 
 #### Scenario: 垂直結合セルの変換
 
 - **GIVEN** `morerows=1`属性を持つテーブルセル（2行分）
 - **WHEN** Typst形式に変換する
-- **THEN** 出力は`table.cell(rowspan: 2)[content]`を含む
+- **THEN** 出力は`table.cell(content, rowspan: 2)`を含む
+
+**変更理由**: `table.cell()`の引数順序を修正（content型を第1引数に）。
 
 #### Scenario: 複合結合セルの変換
 
 - **GIVEN** `morecols=1`と`morerows=1`属性を持つテーブルセル
 - **WHEN** Typst形式に変換する
-- **THEN** 出力は`table.cell(colspan: 2, rowspan: 2)[content]`を含む
+- **THEN** 出力は`table.cell(content, colspan: 2, rowspan: 2)`を含む
+
+**変更理由**: `table.cell()`の引数順序を修正。
 
 #### Scenario: ヘッダー内の結合セルの変換
 
 - **GIVEN** `thead`内に`morecols=1`属性を持つヘッダーセル
 - **WHEN** Typst形式に変換する
-- **THEN** 出力は`table.header(table.cell(colspan: 2)[Header], ...)`を含む
+- **THEN** 出力は`table.header(table.cell(content, colspan: 2), ...)`を含む
 - **AND** ヘッダーセルと結合セルの両方の機能が正しく動作する
+
+**変更理由**: `table.cell()`の引数順序を修正し、マークアップモードを削除。
 
 #### Scenario: 複数の結合セルを持つテーブル
 
 - **GIVEN** 同一テーブル内に複数の結合セルが存在する
 - **WHEN** Typst形式に変換する
-- **THEN** すべての結合セルが正しく`table.cell()`でラップされる
-- **AND** 通常セルは`[content]`として出力される
+- **THEN** すべての結合セルが正しく`table.cell(content, ...)`でラップされる
+- **AND** 通常セルは`content`として出力される（マークアップモードなし）
+
+**変更理由**: 一貫性のため、すべてのセルでマークアップモードを削除。
 
 #### Scenario: 結合のないテーブル（後方互換性）
 
 - **GIVEN** `morecols`も`morerows`も持たないテーブル
 - **WHEN** Typst形式に変換する
-- **THEN** すべてのセルは`[content]`として出力される
+- **THEN** すべてのセルは`content`として出力される（マークアップモード `[...]` なし）
 - **AND** `table.cell()`は生成されない（既存の動作を維持）
+
+**変更理由**: Unified Code Mode指針に従い、マークアップモードを削除。
 
 ### Requirement: セル結合情報の保存
 
@@ -274,4 +286,48 @@ translatorは、各セルの結合情報（colspan、rowspan）を保存しな�
 - **WHEN** `depart_entry()`が呼び出される
 - **THEN** セルデータは`{"content": str, "is_header": bool, "colspan": int, "rowspan": int}`形式で保存される
 - **AND** 結合のないセルは`colspan=1, rowspan=1`として保存される
+
+### Requirement: Unified Code Mode準拠のセル出力
+
+テーブルセルの出力は、Unified Code Mode指針に従い、マークアップモード `[...]` を使用せず、content型を直接渡さなければならない (MUST)。
+
+#### Scenario: 通常セルのcontent型出力
+
+- **GIVEN** colspan/rowspanを持たない通常のテーブルセル
+- **AND** セル内容が`par({text("Cell 1")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`par({text("Cell 1")}),`を含む
+- **AND** マークアップモード `[...]` でラップされない
+
+**理由**: Unified Code Mode指針の「マークアップモードを避ける」に従う。
+
+#### Scenario: spanningセルのcontent型第1引数
+
+- **GIVEN** `morecols=1`を持つセル
+- **AND** セル内容が`par({text("Spans 2 cols")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.cell(par({text("Spans 2 cols")}), colspan: 2),`を含む
+- **AND** content型が第1引数として渡される
+
+**理由**: Typst公式の`table.cell(body, colspan: 1, rowspan: 1)`シグネチャに従う。
+
+#### Scenario: ヘッダーセルのcontent型出力
+
+- **GIVEN** `thead`内のヘッダーセル
+- **AND** セル内容が`par({text("Header")})`
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`table.header(par({text("Header")}), ...)`を含む
+- **AND** マークアップモード `[...]` でラップされない
+
+**理由**: ヘッダーセルも通常セルと同様にUnified Code Mode指針に従う。
+
+#### Scenario: 複雑な内容のセル出力
+
+- **GIVEN** 複数の要素を含むセル（例: `text("A") + strong({text("B")})`）
+- **WHEN** Typst形式に変換する
+- **THEN** 出力は`text("A") + strong({text("B")}),`を含む
+- **AND** マークアップモードでラップされない
+- **AND** content型の式が直接渡される
+
+**理由**: 任意のcontent型式を直接渡せることを保証。
 


### PR DESCRIPTION
## Summary

This PR archives the completed OpenSpec change `fix-table-cell-unified-code-mode` that was implemented and merged in PR #65.

## Changes

- **Archive location**: `openspec/changes/archive/2025-10-26-fix-table-cell-unified-code-mode/`
  - `proposal.md`: Original proposal document
  - `tasks.md`: Completed task list
  - `specs/table-rendering/spec.md`: Spec snapshot at time of completion

- **Spec update**: `openspec/specs/table-rendering/spec.md`
  - Applied deltas from the archived change
  - Documents the new table cell syntax (content-first, no markup mode)

## Implementation Status

✅ Implemented in PR #65
✅ All tasks completed
✅ Spec updated with implementation details

## Related

- Implementation PR: #65
- OpenSpec change: `fix-table-cell-unified-code-mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)