### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-10-26
+
+### Fixed
+
+- **Table Cell Unified Code Mode Compliance** ([#65](https://github.com/YuSabo90002/typsphinx/pull/65))
+  - Fixed `table.cell()` argument order to match Typst signature (content as first positional argument)
+  - Removed unnecessary markup mode `[...]` wrapping from table cells
+  - Table cells now pass content type directly: `table.cell(content, colspan: 2)`
+  - Improved consistency with Unified Code Mode guideline across all table elements
+
 ## [0.4.0] - 2025-10-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "typsphinx"
-version = "0.4.0"
+version = "0.4.1"
 description = "Sphinx extension for Typst output"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/typsphinx/__init__.py
+++ b/typsphinx/__init__.py
@@ -11,7 +11,7 @@ sources using Sphinx, which can then be compiled to PDF using the Typst compiler
 :license: MIT, see LICENSE for details.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.1"
 __author__ = "Sphinx Typst Contributors"
 
 from typing import Any, Dict


### PR DESCRIPTION
## Release v0.4.1

This is a patch release that fixes table cell syntax to fully comply with the Unified Code Mode guideline.

### Changes

#### Fixed

- **Table Cell Unified Code Mode Compliance** ([#65](https://github.com/YuSabo90002/typsphinx/pull/65))
  - Fixed `table.cell()` argument order to match Typst signature (content as first positional argument)
  - Removed unnecessary markup mode `[...]` wrapping from table cells
  - Table cells now pass content type directly: `table.cell(content, colspan: 2)`
  - Improved consistency with Unified Code Mode guideline across all table elements

### Version Updates

- `typsphinx/__init__.py`: 0.3.0 → 0.4.1
- `pyproject.toml`: 0.4.0 → 0.4.1
- `CHANGELOG.md`: Added v0.4.1 entry

### Testing

- ✅ All 375 tests pass
- ✅ Code quality checks pass (black, ruff, mypy)
- ✅ Documentation builds successfully
- ✅ Generated Typst files use correct syntax

### Related

- Implementation PR: #65
- Archive PR: #66

---

**Release Checklist:**
- [x] Version numbers updated
- [x] CHANGELOG.md updated
- [x] All tests passing
- [ ] Merge to main
- [ ] Create git tag v0.4.1
- [ ] Create GitHub release
- [ ] Publish to PyPI (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)