### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2025-10-29
+
+### Fixed
+
+- **Empty Table Cells Rendering** ([#68](https://github.com/YuSabo90002/typsphinx/issues/68), [#70](https://github.com/YuSabo90002/typsphinx/pull/70))
+  - Fixed empty table cells causing Typst compilation errors
+  - All table cells (normal and spanning) now wrapped in content blocks `{}`
+  - Empty cells output as `{}` instead of bare commas
+  - Prevents "unexpected comma" syntax errors in Typst
+  - Added 5 comprehensive test cases for empty cell scenarios
+
+- **Image Relative Paths in Nested Documents** ([#69](https://github.com/YuSabo90002/typsphinx/issues/69), [#72](https://github.com/YuSabo90002/typsphinx/pull/72))
+  - Fixed image paths in nested documents failing to resolve during Typst compilation
+  - Implemented `_compute_relative_image_path()` method (mirrors Issue #5 toctree fix)
+  - Image URIs now adjusted based on output file location
+  - Supports all path patterns: root, nested, deep nested, same directory, subdirectory, cross-directory
+  - Added 6 comprehensive test cases for image path adjustment
+  - Backward compatible: root document images unchanged
+
 ## [0.4.1] - 2025-10-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -319,5 +319,5 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 ---
 
-**Status**: Stable (v0.4.0) - Production ready
+**Status**: Stable (v0.4.2) - Production ready
 **Python**: 3.9+ | **Sphinx**: 5.0+ | **Typst**: 0.11.1+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "typsphinx"
-version = "0.4.1"
+version = "0.4.2"
 description = "Sphinx extension for Typst output"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release Summary

Prepare for v0.4.2 release with two important bug fixes for table rendering and image path handling in nested documents.

## Changes

### Version Updates
- Update version to `0.4.2` in `pyproject.toml`
- Update status to `v0.4.2` in `README.md`
- Add release notes to `CHANGELOG.md`

### Release Notes (v0.4.2 - 2025-10-29)

#### Fixed

**1. Empty Table Cells Rendering** ([#68](https://github.com/YuSabo90002/typsphinx/issues/68), [#70](https://github.com/YuSabo90002/typsphinx/pull/70))
- Fixed empty table cells causing Typst compilation errors
- All table cells (normal and spanning) now wrapped in content blocks `{}`
- Empty cells output as `{}` instead of bare commas
- Prevents "unexpected comma" syntax errors in Typst
- Added 5 comprehensive test cases for empty cell scenarios

**2. Image Relative Paths in Nested Documents** ([#69](https://github.com/YuSabo90002/typsphinx/issues/69), [#72](https://github.com/YuSabo90002/typsphinx/pull/72))
- Fixed image paths in nested documents failing to resolve during Typst compilation
- Implemented `_compute_relative_image_path()` method (mirrors Issue #5 toctree fix)
- Image URIs now adjusted based on output file location
- Supports all path patterns: root, nested, deep nested, same directory, subdirectory, cross-directory
- Added 6 comprehensive test cases for image path adjustment
- Backward compatible: root document images unchanged

## Testing

✅ All 381 tests pass  
✅ Code quality checks pass (black, ruff, mypy)  
✅ New test coverage for both fixes

## Checklist

- [x] Version updated in `pyproject.toml`
- [x] Changelog updated with release notes
- [x] README status updated
- [x] All tests passing
- [x] Code quality checks passing

## Next Steps

After merge:
1. Create GitHub release with tag `v0.4.2`
2. Publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)