### PR TITLE
chore: upgrade OpenSpec to v0.13.0

### DIFF
--- a/.claude/commands/openspec/archive.md
+++ b/.claude/commands/openspec/archive.md
@@ -11,11 +11,17 @@ tags: [openspec, archive]
 - Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
 
 **Steps**
-1. Identify the requested change ID (via the prompt or `openspec list`).
-2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
-3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
-4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+1. Determine the change ID to archive:
+   - If this prompt already includes a specific change ID (for example inside a `<ChangeId>` block populated by slash-command arguments), use that value after trimming whitespace.
+   - If the conversation references a change loosely (for example by title or summary), run `openspec list` to surface likely IDs, share the relevant candidates, and confirm which one the user intends.
+   - Otherwise, review the conversation, run `openspec list`, and ask the user which change to archive; wait for a confirmed change ID before proceeding.
+   - If you still cannot identify a single change ID, stop and tell the user you cannot archive anything yet.
+2. Validate the change ID by running `openspec list` (or `openspec show <id>`) and stop if the change is missing, already archived, or otherwise not ready to archive.
+3. Run `openspec archive <id> --yes` so the CLI moves the change and applies spec updates without prompts (use `--skip-specs` only for tooling-only work).
+4. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+5. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
 
 **Reference**
+- Use `openspec list` to confirm change IDs before archiving.
 - Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
 <!-- OPENSPEC:END -->

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -60,7 +60,7 @@ Track these steps as TODOs and complete them one by one.
 After deployment, create separate PR to:
 - Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
 - Update `specs/` if capabilities changed
-- Use `openspec archive [change] --skip-specs --yes` for tooling-only changes
+- Use `openspec archive <change-id> --skip-specs --yes` for tooling-only changes (always pass the change ID explicitly)
 - Run `openspec validate --strict` to confirm the archived change passes checks
 
 ## Before Any Task
@@ -95,9 +95,8 @@ After deployment, create separate PR to:
 openspec list                  # List active changes
 openspec list --specs          # List specifications
 openspec show [item]           # Display change or spec
-openspec diff [change]         # Show spec differences
 openspec validate [item]       # Validate changes or specs
-openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
+openspec archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
 # Project management
 openspec init [path]           # Initialize OpenSpec
@@ -448,9 +447,8 @@ Only add complexity with:
 ```bash
 openspec list              # What's in progress?
 openspec show [item]       # View details
-openspec diff [change]     # What's changing?
 openspec validate --strict # Is it correct?
-openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
+openspec archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.


### PR DESCRIPTION
## Summary
- Upgrade OpenSpec from 0.12.0 to 0.13.0
- Updated managed instruction blocks in AGENTS.md and archive command
- No breaking changes, all existing specs remain compatible

## Changes in v0.13.0
- **New AI coding assistant support**: CodeBuddy Code, Cline, Crush AI, Auggie
- **Improved archive command**: Enhanced change ID validation and handling
- **Enhanced delta spec validation**: Case-insensitive headers, empty section detection
- **Fixed archive validation**: Proper `--no-validate` flag handling
- **Documentation improvements**: Clearer command usage and examples

## Files Updated
- `openspec/AGENTS.md`: Updated with v0.13.0 improvements
- `.claude/commands/openspec/archive.md`: Enhanced change ID validation steps

## Test Plan
- [x] Verified openspec commands still work (`openspec --version` shows 0.13.0)
- [x] Reviewed updated instruction blocks
- [x] Confirmed no breaking changes to existing project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)