### PR TITLE
Proposal: Support for template-associated assets

### DIFF
--- a/openspec/changes/add-template-assets/design.md
+++ b/openspec/changes/add-template-assets/design.md
@@ -1,0 +1,358 @@
+# Design: Template Asset Support
+
+## Overview
+
+This design extends the template system to automatically copy assets (fonts, images, logos) referenced by custom Typst templates. The implementation follows the existing `copy_image_files()` pattern established in Issue #38.
+
+## Implementation Options
+
+### Option 1: Automatic Directory Copy (Recommended)
+
+**Approach**: When `typst_template` points to a file, automatically copy all files in the same directory.
+
+```python
+# conf.py
+typst_template = "_templates/corporate/template.typ"
+```
+
+**Behavior**:
+- Copy `_templates/corporate/` directory (entire folder) to output directory
+- Preserves directory structure
+- Simple for users - no configuration needed
+
+**Pros**:
+- ✅ Zero configuration
+- ✅ Intuitive - "template directory contains everything"
+- ✅ Handles most use cases
+
+**Cons**:
+- ⚠️ May copy unnecessary files
+- ⚠️ Less granular control
+
+### Option 2: Configuration-Based Asset List
+
+**Approach**: Add `typst_template_assets` configuration for explicit asset specification.
+
+```python
+# conf.py
+typst_template = "_templates/template.typ"
+typst_template_assets = [
+    "_templates/logo.png",
+    "_templates/fonts/",
+    "_templates/icons/*.svg"
+]
+```
+
+**Behavior**:
+- Copy only specified files/directories
+- Supports glob patterns
+- Explicit control
+
+**Pros**:
+- ✅ Granular control
+- ✅ Avoid copying unnecessary files
+- ✅ Clear documentation of dependencies
+
+**Cons**:
+- ⚠️ Requires manual configuration
+- ⚠️ Users must know what assets are needed
+
+### Option 3: Automatic Asset Detection (Future Enhancement)
+
+**Approach**: Parse template file to detect `#image()`, `#font()`, etc. and copy referenced files.
+
+**Example**:
+```typst
+// template.typ
+#image("logo.png")  // Detected → copy logo.png
+#set text(font: "CustomFont.otf")  // Detected → copy CustomFont.otf
+```
+
+**Pros**:
+- ✅ Fully automatic
+- ✅ No configuration needed
+- ✅ Copies only what's used
+
+**Cons**:
+- ⚠️ Complex parsing required
+- ⚠️ May miss dynamic references
+- ⚠️ Deferred to future version
+
+## Recommended Approach
+
+**Hybrid: Option 1 + Option 2**
+
+1. **Default Behavior (Option 1)**: Automatically copy template directory
+2. **Override (Option 2)**: Use `typst_template_assets` for granular control
+
+```python
+# Simple case - automatic
+typst_template = "_templates/template.typ"
+# Copies entire _templates/ directory
+
+# Advanced case - explicit
+typst_template = "_templates/template.typ"
+typst_template_assets = [
+    "_templates/logo.png",
+    "_templates/fonts/"
+]
+# Copies only specified assets
+```
+
+## Architecture
+
+### Modified Components
+
+#### 1. `TypstBuilder` Class ([builder.py](../../typsphinx/builder.py))
+
+Add new method `copy_template_assets()` similar to `copy_image_files()`:
+
+```python
+def copy_template_assets(self) -> None:
+    """
+    Copy template-associated assets to the output directory.
+
+    If typst_template_assets is configured, copies specified files.
+    Otherwise, copies the entire template directory.
+    """
+    template_path = getattr(self.config, "typst_template", None)
+    if not template_path:
+        return  # No custom template
+
+    template_assets = getattr(self.config, "typst_template_assets", None)
+
+    if template_assets:
+        # Option 2: Explicit asset list
+        self._copy_explicit_assets(template_assets)
+    else:
+        # Option 1: Automatic directory copy
+        self._copy_template_directory(template_path)
+```
+
+#### 2. Configuration Registration ([__init__.py](../../typsphinx/__init__.py))
+
+Add new configuration value:
+
+```python
+app.add_config_value("typst_template_assets", None, "html", [list, type(None)])
+```
+
+#### 3. Build Process Integration
+
+Call `copy_template_assets()` in `finish()` method:
+
+```python
+def finish(self) -> None:
+    """Finish the build process."""
+    self.copy_image_files()      # Existing
+    self.copy_template_assets()  # New
+```
+
+### File Copying Logic
+
+#### Automatic Directory Copy (Option 1)
+
+```python
+def _copy_template_directory(self, template_path: str) -> None:
+    """Copy entire template directory to output."""
+    template_dir = os.path.dirname(template_path)
+    src_dir = os.path.join(self.srcdir, template_dir)
+    dest_dir = os.path.join(self.outdir, template_dir)
+
+    if not os.path.exists(src_dir):
+        return
+
+    # Copy directory, excluding template file itself
+    # (template file is handled separately in write_template_file())
+    for root, dirs, files in os.walk(src_dir):
+        for file in files:
+            if file.endswith('.typ'):
+                continue  # Skip .typ files
+
+            src_file = os.path.join(root, file)
+            rel_path = os.path.relpath(src_file, src_dir)
+            dest_file = os.path.join(dest_dir, rel_path)
+
+            ensuredir(os.path.dirname(dest_file))
+            shutil.copy2(src_file, dest_file)
+```
+
+#### Explicit Asset Copy (Option 2)
+
+```python
+def _copy_explicit_assets(self, assets: List[str]) -> None:
+    """Copy explicitly specified assets."""
+    for asset_pattern in assets:
+        # Support glob patterns
+        if '*' in asset_pattern:
+            matches = glob.glob(os.path.join(self.srcdir, asset_pattern))
+            for match in matches:
+                self._copy_single_asset(match)
+        else:
+            src = os.path.join(self.srcdir, asset_pattern)
+            self._copy_single_asset(src)
+
+def _copy_single_asset(self, src_path: str) -> None:
+    """Copy a single asset file or directory."""
+    if os.path.isdir(src_path):
+        # Copy directory recursively
+        ...
+    elif os.path.isfile(src_path):
+        # Copy single file
+        ...
+```
+
+## Edge Cases and Considerations
+
+### 1. Typst Universe Packages
+
+**Question**: Should this affect `typst_package` configuration?
+
+**Answer**: **No**. Typst Universe packages (e.g., `@preview/charged-ieee:0.1.0`) are handled by the Typst compiler itself. Package assets are downloaded and managed automatically by Typst. This feature only applies to **local custom templates** (`typst_template`).
+
+```python
+# This does NOT need asset copying (Typst handles it)
+typst_package = "@preview/charged-ieee:0.1.0"
+
+# This DOES need asset copying (local template)
+typst_template = "_templates/custom.typ"
+```
+
+### 2. Template File Duplication
+
+**Issue**: Template file itself is already copied by `write_template_file()`. Should `copy_template_assets()` also copy it?
+
+**Answer**: **No**. Skip `.typ` files to avoid duplication. `write_template_file()` already handles template copying.
+
+### 3. Relative Paths in Templates
+
+**Issue**: Template references `assets/logo.png`. Should we preserve directory structure?
+
+**Answer**: **Yes**. Preserve relative paths so template references remain valid.
+
+```
+Source:
+  _templates/
+    template.typ         → references "assets/logo.png"
+    assets/
+      logo.png
+
+Output:
+  _templates/
+    template.typ         → references still valid
+    assets/
+      logo.png
+```
+
+### 4. Non-Existent Assets
+
+**Issue**: What if specified assets don't exist?
+
+**Answer**: Log a warning, but don't fail the build. Similar to `copy_image_files()` behavior.
+
+```python
+if not os.path.exists(src):
+    logger.warning(f"Template asset not found: {src}")
+    continue
+```
+
+### 5. Performance Impact
+
+**Issue**: Copying large template directories could slow builds.
+
+**Answer**:
+- Only copy when `typst_template` is set
+- Skip if template directory hasn't changed (use timestamp comparison in future optimization)
+- Users can use `typst_template_assets` for granular control
+
+## Testing Strategy
+
+### Unit Tests
+
+1. Test `copy_template_assets()` with various configurations
+2. Test automatic directory copy
+3. Test explicit asset list
+4. Test glob pattern matching
+5. Test missing asset handling
+
+### Integration Tests
+
+1. Build project with custom template and assets
+2. Verify assets are copied correctly
+3. Verify Typst compilation succeeds
+4. Verify no regression for projects without templates
+
+### E2E Tests
+
+1. Create example project with logo, fonts, images
+2. Build PDF and verify assets are rendered
+3. Test both `typst` and `typstpdf` builders
+
+## Documentation Updates
+
+### User Guide
+
+Add section "Using Custom Templates with Assets":
+
+```markdown
+## Custom Templates with Assets
+
+### Automatic Asset Copying (Recommended)
+
+Place your template and assets in the same directory:
+
+├── _templates/
+│   ├── template.typ
+│   ├── logo.png
+│   └── fonts/
+│       └── CustomFont.otf
+
+Configure template path:
+
+```python
+typst_template = "_templates/template.typ"
+```
+
+All files in `_templates/` will be automatically copied.
+
+### Explicit Asset Specification
+
+For granular control, specify assets explicitly:
+
+```python
+typst_template = "_templates/template.typ"
+typst_template_assets = [
+    "_templates/logo.png",
+    "_templates/fonts/*.otf"
+]
+```
+
+## Migration Guide
+
+### Existing Projects
+
+**No migration needed**. This feature is backward compatible:
+
+- Projects without `typst_template` → no change
+- Projects with `typst_template` but no assets → no change
+- Projects with manually copied assets → automatic copying takes over (can remove manual steps)
+
+### Opting Out
+
+To disable automatic asset copying (e.g., for performance):
+
+```python
+typst_template = "_templates/template.typ"
+typst_template_assets = []  # Empty list = no automatic copying
+```
+
+## Future Enhancements
+
+1. **Asset Detection**: Parse template files to auto-detect referenced assets (Option 3)
+2. **Incremental Copying**: Only copy changed assets (timestamp comparison)
+3. **Asset Validation**: Warn about unused assets or missing references
+4. **Remote Assets**: Support HTTP URLs for downloading remote assets
+
+## Implementation Sequence
+
+See `tasks.md` for detailed implementation tasks.

--- a/openspec/changes/add-template-assets/proposal.md
+++ b/openspec/changes/add-template-assets/proposal.md
@@ -1,0 +1,94 @@
+# Proposal: Support for Template-Associated Assets
+
+## Problem
+
+When using custom Typst templates via `typst_template` configuration, the template file itself (`_template.typ`) is correctly copied to the output directory. However, assets referenced by the template (fonts, logos, images, icons, watermarks, etc.) are **not** automatically copied, causing Typst compilation to fail with "file not found" errors.
+
+### Current Behavior
+
+```python
+# conf.py
+typst_template = "_templates/custom_template.typ"
+```
+
+```typst
+// _templates/custom_template.typ
+#import "assets/logo.png"
+#set text(font: "assets/CustomFont.otf")
+#image("assets/watermark.svg")
+```
+
+**Result**:
+- ✅ `_template.typ` is copied to output directory
+- ❌ `assets/` directory is NOT copied
+- ❌ Typst compilation fails: "file not found: assets/logo.png"
+
+### Expected Behavior
+
+Assets referenced by the template should be automatically available in the output directory, similar to how images referenced in the document content are copied via `copy_image_files()`.
+
+## Use Cases
+
+### 1. Corporate Branding
+Organizations need to embed company logos, branded fonts, and visual elements in document templates.
+
+```typst
+// Company template
+#image("logo.png")  // Company logo in header
+#set text(font: "CompanyFont.otf")  // Branded font
+```
+
+### 2. Academic Papers
+Research paper templates (e.g., IEEE, ACM) often require specific logos or symbols.
+
+```typst
+// IEEE template
+#image("ieee-logo.png")
+#image("conference-badge.svg")
+```
+
+### 3. Custom Document Designs
+Templates with decorative elements, watermarks, or background images.
+
+```typst
+// Creative template
+#place(center + horizon, image("watermark.svg", width: 100%))
+#image("border-design.png")
+```
+
+## Related Issues
+
+- **Issue #75**: [FEATURE] Support for template-associated assets
+
+## Related Specifications
+
+- `template-system` - Current template configuration and handling
+- `document-conversion` - File copying and asset management (images via `copy_image_files()`)
+
+## Scope
+
+This change affects:
+- Template asset discovery and copying
+- Configuration for specifying template assets
+- Build process (`TypstBuilder` and `TypstPDFBuilder`)
+
+This change does NOT affect:
+- Typst Universe packages (`typst_package`) - these handle assets automatically
+- Document content images - already handled by `copy_image_files()`
+- Template rendering logic - only concerns asset file copying
+
+## Constraints
+
+- **Backward Compatibility**: Must not break existing projects that don't use template assets
+- **Opt-in**: Asset copying should only occur when templates reference assets
+- **Consistency**: Should follow the same pattern as `copy_image_files()` from Issue #38
+- **Performance**: Should not slow down builds for projects without template assets
+
+## Success Criteria
+
+1. ✅ Templates can reference assets (fonts, images, logos) without manual file copying
+2. ✅ Assets are automatically copied to the output directory
+3. ✅ Builds succeed without "file not found" errors
+4. ✅ Configuration is intuitive and well-documented
+5. ✅ Backward compatible with existing projects
+6. ✅ Works with both `typst` and `typstpdf` builders

--- a/openspec/changes/add-template-assets/specs/template-system/spec.md
+++ b/openspec/changes/add-template-assets/specs/template-system/spec.md
@@ -1,0 +1,210 @@
+# template-system Spec Delta
+
+## ADDED Requirements
+
+### Requirement: テンプレートアセットの自動コピー
+
+カスタムTypstテンプレート(`typst_template`)使用時に、テンプレートが参照するアセット(フォント、画像、ロゴ等)を出力ディレクトリに自動的にコピーしなければならない（MUST）。
+
+#### Scenario: テンプレートディレクトリの自動コピー（デフォルト動作）
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template = "_templates/corporate/template.typ"
+  ```
+- **AND** `_templates/corporate/` ディレクトリに以下のファイルが存在する
+  ```
+  _templates/corporate/
+    ├── template.typ
+    ├── logo.png
+    └── assets/
+        └── font.otf
+  ```
+- **AND** `typst_template_assets` が設定されていない
+- **WHEN** Typst ビルドを実行する
+- **THEN** `_templates/corporate/` ディレクトリ全体が出力ディレクトリにコピーされる
+- **AND** `template.typ` 内の `#image("logo.png")` 参照が正常に動作する
+- **AND** `#set text(font: "assets/font.otf")` 参照が正常に動作する
+
+#### Scenario: 明示的なアセット指定
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template = "_templates/template.typ"
+  typst_template_assets = [
+      "_templates/logo.png",
+      "_templates/fonts/"
+  ]
+  ```
+- **WHEN** Typst ビルドを実行する
+- **THEN** `logo.png` ファイルがコピーされる
+- **AND** `fonts/` ディレクトリ全体がコピーされる
+- **AND** リストに含まれないファイルはコピーされない
+
+#### Scenario: Globパターンによるアセット指定
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template = "_templates/template.typ"
+  typst_template_assets = [
+      "_templates/assets/*.png",
+      "_templates/fonts/*.otf"
+  ]
+  ```
+- **WHEN** Typst ビルドを実行する
+- **THEN** `_templates/assets/` 内のすべての `.png` ファイルがコピーされる
+- **AND** `_templates/fonts/` 内のすべての `.otf` ファイルがコピーされる
+- **AND** パターンに一致しないファイルはコピーされない
+
+#### Scenario: 相対パス構造の保持
+
+- **GIVEN** テンプレートが以下のディレクトリ構造を持つ
+  ```
+  _templates/
+    ├── template.typ
+    └── assets/
+        └── nested/
+            └── logo.png
+  ```
+- **AND** `template.typ` 内で `#image("assets/nested/logo.png")` を参照している
+- **WHEN** Typst ビルドを実行する
+- **THEN** 出力ディレクトリに以下の構造が作成される
+  ```
+  output/
+    └── _templates/
+        ├── template.typ
+        └── assets/
+            └── nested/
+                └── logo.png
+  ```
+- **AND** テンプレート内の相対パス参照が正常に動作する
+
+#### Scenario: 存在しないアセットの処理
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template_assets = [
+      "_templates/existing.png",
+      "_templates/missing.png"
+  ]
+  ```
+- **AND** `missing.png` が存在しない
+- **WHEN** Typst ビルドを実行する
+- **THEN** `existing.png` は正常にコピーされる
+- **AND** `missing.png` について警告がログに記録される
+- **AND** ビルドは失敗しない（警告のみ）
+
+#### Scenario: アセットコピーの無効化
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template = "_templates/template.typ"
+  typst_template_assets = []  # 空のリスト
+  ```
+- **WHEN** Typst ビルドを実行する
+- **THEN** テンプレートディレクトリの自動コピーは実行されない
+- **AND** `template.typ` のみがコピーされる（既存の動作）
+
+### Requirement: Typst Universeパッケージとの区別
+
+`typst_package`で指定されたTypst Universeパッケージについては、アセットの自動コピーを実行してはならない（MUST NOT）。パッケージのアセットはTypstコンパイラが自動的に処理する。
+
+#### Scenario: Typst Universeパッケージ使用時
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_package = "@preview/charged-ieee:0.1.0"
+  ```
+- **AND** `typst_template` が設定されていない
+- **WHEN** Typst ビルドを実行する
+- **THEN** アセットコピー処理は実行されない
+- **AND** パッケージのアセット(ロゴ、フォント等)はTypstコンパイラが自動的に処理する
+
+#### Scenario: ローカルテンプレートとパッケージの併用
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_package = "@preview/codly:1.3.0"  # パッケージ（アセット自動）
+  typst_template = "_templates/custom.typ"  # ローカルテンプレート（アセット要コピー）
+  ```
+- **WHEN** Typst ビルドを実行する
+- **THEN** `_templates/` ディレクトリのアセットのみがコピーされる
+- **AND** `codly` パッケージのアセットは Typst コンパイラが処理する
+
+### Requirement: 後方互換性の保証
+
+アセット自動コピー機能は、既存プロジェクト（`typst_template` を使用していないプロジェクト）に影響を与えてはならない（MUST NOT）。
+
+#### Scenario: typst_template 未設定のプロジェクト
+
+- **GIVEN** `conf.py` に `typst_template` が設定されていない
+- **WHEN** Typst ビルドを実行する
+- **THEN** アセットコピー処理は実行されない
+- **AND** 既存の動作と完全に互換性がある
+
+#### Scenario: テンプレートのみでアセットなしのプロジェクト
+
+- **GIVEN** `conf.py` に以下の設定が存在する
+  ```python
+  typst_template = "_templates/simple.typ"
+  ```
+- **AND** `_templates/` ディレクトリに `simple.typ` のみが存在する（アセットなし）
+- **WHEN** Typst ビルドを実行する
+- **THEN** `simple.typ` が正常にコピーされる（既存の動作）
+- **AND** 追加のアセットコピーは発生しない（アセットがないため）
+- **AND** ビルドは成功する
+
+### Requirement: 設定値の定義
+
+テンプレートアセット指定用の新しい設定値 `typst_template_assets` を提供しなければならない（MUST）。
+
+#### Scenario: 設定値の型と デフォルト値
+
+- **GIVEN** Sphinx 拡張が初期化される
+- **WHEN** `typst_template_assets` 設定値を確認する
+- **THEN** 以下の仕様を満たす
+  - 型: `list` または `None`
+  - デフォルト値: `None`
+  - rebuild タイプ: `html`（テンプレート変更時に再ビルドが必要）
+
+#### Scenario: 設定値のドキュメント
+
+- **GIVEN** ユーザーガイドが存在する
+- **WHEN** `typst_template_assets` の説明を確認する
+- **THEN** 以下の情報が含まれる
+  - 設定の目的（テンプレートアセットの明示的指定）
+  - デフォルト動作（`None` の場合はテンプレートディレクトリ全体をコピー）
+  - 例（ファイル指定、ディレクトリ指定、Globパターン）
+  - 空リストでの無効化方法
+
+### Requirement: コピー処理の実装
+
+`TypstBuilder` クラスに `copy_template_assets()` メソッドを実装し、`finish()` メソッドから呼び出さなければならない（MUST）。
+
+#### Scenario: ビルドプロセスへの統合
+
+- **GIVEN** Typst ビルダーが実行される
+- **WHEN** `finish()` メソッドが呼び出される
+- **THEN** `copy_image_files()` の後に `copy_template_assets()` が呼び出される
+- **AND** 両方のメソッドが正常に実行される
+
+#### Scenario: copy_template_assets() の動作
+
+- **GIVEN** `copy_template_assets()` メソッドが実装されている
+- **WHEN** メソッドが呼び出される
+- **THEN** 以下の処理が実行される
+  1. `typst_template` 設定を確認
+  2. テンプレートが設定されていない場合は早期リターン
+  3. `typst_template_assets` 設定を確認
+  4. アセットが明示的に指定されている場合は、それらのみをコピー
+  5. アセットが指定されていない場合は、テンプレートディレクトリ全体をコピー
+  6. コピー処理中のエラーは警告としてログ記録し、ビルドは継続
+
+#### Scenario: ログ出力
+
+- **GIVEN** テンプレートアセットが存在する
+- **WHEN** `copy_template_assets()` が実行される
+- **THEN** 以下のログが出力される
+  - `INFO: Copying template assets...`（コピー開始時）
+  - `DEBUG: Copied template asset: {path}`（各ファイルごと）
+  - `WARNING: Template asset not found: {path}`（存在しないアセット）

--- a/openspec/changes/add-template-assets/tasks.md
+++ b/openspec/changes/add-template-assets/tasks.md
@@ -1,0 +1,366 @@
+# Implementation Tasks
+
+## Phase 1: Configuration and Foundation
+
+### Task 1.1: Add `typst_template_assets` configuration value
+**Deliverable**: New configuration registered in `__init__.py`
+
+- [ ] Add `typst_template_assets` to `setup()` function in `typsphinx/__init__.py`
+- [ ] Type: `list | None`, default: `None`, rebuild: `html`
+- [ ] Add inline documentation comment
+
+**Validation**:
+- Configuration value is accessible via `self.config.typst_template_assets`
+- Sphinx accepts list of strings or None
+- No errors during extension initialization
+
+**Files**: `typsphinx/__init__.py`
+
+---
+
+### Task 1.2: Create `copy_template_assets()` method skeleton
+**Deliverable**: Empty method with docstring in `TypstBuilder`
+
+- [ ] Add `copy_template_assets()` method to `TypstBuilder` class in `builder.py`
+- [ ] Write comprehensive docstring (similar to `copy_image_files()`)
+- [ ] Add early return if `typst_template` is not configured
+- [ ] Add logging: `logger.info("Copying template assets...")`
+
+**Validation**:
+- Method exists and can be called
+- Returns early when no template is configured
+- No exceptions raised
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+### Task 1.3: Integrate into build process
+**Deliverable**: `copy_template_assets()` called during build
+
+- [ ] Call `self.copy_template_assets()` in `finish()` method after `copy_image_files()`
+- [ ] Ensure it's called for both `TypstBuilder` and `TypstPDFBuilder`
+
+**Validation**:
+- Run test build and verify method is called (check logs)
+- No regression in existing builds
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+## Phase 2: Automatic Directory Copy (Default Behavior)
+
+### Task 2.1: Implement automatic template directory copy
+**Deliverable**: Copy entire template directory when `typst_template_assets` is None
+
+- [ ] Extract template directory path from `typst_template` configuration
+- [ ] Walk template directory recursively using `os.walk()`
+- [ ] Skip `.typ` files (already handled by `write_template_file()`)
+- [ ] Copy each file preserving relative path structure
+- [ ] Use `shutil.copy2()` to preserve metadata
+- [ ] Create destination directories with `ensuredir()`
+- [ ] Handle missing source directory gracefully (log warning, continue)
+
+**Validation**:
+- Create test project with template directory containing assets
+- Run build and verify all assets are copied
+- Verify `.typ` files are not duplicated
+- Verify directory structure is preserved
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+### Task 2.2: Add error handling and logging
+**Deliverable**: Robust error handling for file operations
+
+- [ ] Wrap file copy in try-except block
+- [ ] Log warnings for individual copy failures (don't fail entire build)
+- [ ] Log debug message for each successfully copied file
+- [ ] Log info message with total count at the end
+
+**Validation**:
+- Manually create permission errors or missing files
+- Verify warnings are logged but build continues
+- Check log output contains useful information
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+## Phase 3: Explicit Asset Specification
+
+### Task 3.1: Implement explicit asset list copying
+**Deliverable**: Support `typst_template_assets` configuration
+
+- [ ] Check if `typst_template_assets` is configured and non-empty
+- [ ] Iterate through asset list
+- [ ] For each asset path:
+  - Resolve absolute path from source directory
+  - Check if file or directory
+  - Copy file or directory recursively
+  - Preserve relative path in output
+
+**Validation**:
+- Configure `typst_template_assets = ["_templates/logo.png"]`
+- Run build and verify only specified file is copied
+- Verify files not in list are not copied
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+### Task 3.2: Add glob pattern support
+**Deliverable**: Support wildcards in asset paths
+
+- [ ] Import `glob` module
+- [ ] Detect patterns containing `*` or `?`
+- [ ] Use `glob.glob()` to expand patterns
+- [ ] Copy all matched files/directories
+- [ ] Handle no matches gracefully (log warning)
+
+**Validation**:
+- Configure `typst_template_assets = ["_templates/assets/*.png"]`
+- Create multiple PNG files in `_templates/assets/`
+- Run build and verify all PNGs are copied
+- Verify non-PNG files are not copied
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+### Task 3.3: Implement empty list behavior (opt-out)
+**Deliverable**: Empty list disables automatic copying
+
+- [ ] Check if `typst_template_assets == []` (empty list)
+- [ ] Return early without copying (similar to no template case)
+- [ ] Log debug message: "Template asset copying disabled"
+
+**Validation**:
+- Configure `typst_template_assets = []`
+- Run build and verify no assets are copied
+- Verify only template file itself is copied
+
+**Files**: `typsphinx/builder.py`
+
+---
+
+## Phase 4: Testing
+
+### Task 4.1: Unit tests for `copy_template_assets()`
+**Deliverable**: Test coverage for new method
+
+- [ ] Test with no template configured (early return)
+- [ ] Test automatic directory copy
+- [ ] Test explicit asset list
+- [ ] Test glob patterns
+- [ ] Test empty list (opt-out)
+- [ ] Test missing source files (warnings, no failure)
+- [ ] Test missing template directory (graceful handling)
+
+**Validation**:
+- All tests pass
+- Coverage for `copy_template_assets()` is >90%
+
+**Files**: `tests/test_builder.py`
+
+---
+
+### Task 4.2: Integration tests with example projects
+**Deliverable**: End-to-end validation with real projects
+
+- [ ] Create test project with custom template and assets
+- [ ] Structure:
+  ```
+  _templates/
+    ├── template.typ
+    ├── logo.png
+    └── fonts/
+        └── custom.otf
+  ```
+- [ ] Configure `typst_template = "_templates/template.typ"`
+- [ ] Run build and verify assets are copied
+- [ ] Verify template references work (build PDF successfully)
+
+**Validation**:
+- Build succeeds
+- All assets present in output directory
+- PDF renders correctly with logo and fonts
+
+**Files**: `tests/test_integration.py` or `tests/fixtures/`
+
+---
+
+### Task 4.3: Backward compatibility tests
+**Deliverable**: Ensure no regression in existing projects
+
+- [ ] Run full test suite (317 existing tests)
+- [ ] Verify all tests pass
+- [ ] Test projects without `typst_template` (no change)
+- [ ] Test projects with `typst_template` but no assets (no errors)
+
+**Validation**:
+- All 317 existing tests pass
+- Coverage remains ≥94%
+- No new warnings or errors
+
+**Files**: All existing test files
+
+---
+
+## Phase 5: Documentation
+
+### Task 5.1: Update user guide
+**Deliverable**: Documentation for template assets feature
+
+- [ ] Add section "Using Custom Templates with Assets" to user guide
+- [ ] Document automatic directory copy (default behavior)
+- [ ] Document `typst_template_assets` configuration
+- [ ] Provide examples:
+  - Simple case (automatic)
+  - Explicit asset list
+  - Glob patterns
+  - Opt-out (empty list)
+- [ ] Explain difference between `typst_template` and `typst_package`
+
+**Validation**:
+- Documentation builds without errors
+- Examples are clear and tested
+
+**Files**: `docs/usage.rst` or similar
+
+---
+
+### Task 5.2: Add example project
+**Deliverable**: Working example with template assets
+
+- [ ] Create `examples/template-with-assets/` directory
+- [ ] Include template file with logo and font references
+- [ ] Include actual asset files (logo.png, font file)
+- [ ] Include `conf.py` with minimal configuration
+- [ ] Include README explaining the example
+
+**Validation**:
+- Example builds successfully
+- PDF includes logo and uses custom font
+- README is clear and helpful
+
+**Files**: `examples/template-with-assets/`
+
+---
+
+### Task 5.3: Update CHANGELOG
+**Deliverable**: Release notes entry
+
+- [ ] Add entry under "Unreleased" or next version
+- [ ] Describe new feature: "Template asset auto-copy"
+- [ ] Mention `typst_template_assets` configuration
+- [ ] Note backward compatibility
+
+**Validation**:
+- CHANGELOG follows project conventions
+- Entry is clear and informative
+
+**Files**: `CHANGELOG.md`
+
+---
+
+## Phase 6: Polish and Release
+
+### Task 6.1: Code quality checks
+**Deliverable**: Pass all linters and type checkers
+
+- [ ] Run `uv run black .` (format code)
+- [ ] Run `uv run ruff check .` (lint)
+- [ ] Run `uv run mypy typsphinx/` (type check)
+- [ ] Fix any issues
+
+**Validation**:
+- All quality checks pass
+- No new warnings
+
+**Dependencies**: All implementation tasks complete
+
+---
+
+### Task 6.2: Final integration testing
+**Deliverable**: Comprehensive validation
+
+- [ ] Test on multiple operating systems (if possible)
+- [ ] Test with different template structures
+- [ ] Test with large asset directories
+- [ ] Test error cases (permissions, missing files)
+
+**Validation**:
+- All tests pass on all platforms
+- Edge cases handled gracefully
+
+**Dependencies**: Task 6.1
+
+---
+
+### Task 6.3: Update version and prepare release
+**Deliverable**: Ready for merge
+
+- [ ] Update version in `pyproject.toml` (if releasing)
+- [ ] Finalize CHANGELOG entry
+- [ ] Create pull request with clear description
+- [ ] Link to Issue #75
+
+**Validation**:
+- PR description explains feature clearly
+- References Issue #75 with "Closes #75"
+- CI/CD passes
+
+**Dependencies**: All previous tasks
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (Foundation)
+  ├─ 1.1 → 1.2 → 1.3
+
+Phase 2 (Auto Copy)
+  ├─ 2.1 (depends on 1.3)
+  └─ 2.2 (depends on 2.1)
+
+Phase 3 (Explicit Assets)
+  ├─ 3.1 (depends on 1.3)
+  ├─ 3.2 (depends on 3.1)
+  └─ 3.3 (depends on 3.1)
+
+Phase 4 (Testing)
+  ├─ 4.1 (depends on 2.2, 3.3)
+  ├─ 4.2 (depends on 4.1)
+  └─ 4.3 (depends on 4.2)
+
+Phase 5 (Documentation)
+  ├─ 5.1 (can start anytime, finalize after 4.3)
+  ├─ 5.2 (depends on 4.2)
+  └─ 5.3 (depends on 4.3)
+
+Phase 6 (Release)
+  ├─ 6.1 (depends on 5.3)
+  ├─ 6.2 (depends on 6.1)
+  └─ 6.3 (depends on 6.2)
+```
+
+## Parallelization Opportunities
+
+- Tasks 2.1-2.2 and 3.1-3.3 can be worked on in parallel (different code paths)
+- Tasks 5.1 and 5.2 can be started early and finalized later
+- Testing (Phase 4) must wait for implementation complete
+
+## Estimated Effort
+
+- **Phase 1**: 1-2 hours (foundation)
+- **Phase 2**: 2-3 hours (auto copy logic)
+- **Phase 3**: 2-3 hours (explicit assets + glob)
+- **Phase 4**: 3-4 hours (comprehensive testing)
+- **Phase 5**: 2-3 hours (documentation)
+- **Phase 6**: 1-2 hours (polish)
+
+**Total**: 11-17 hours (approximately 2-3 days of focused work)


### PR DESCRIPTION
## Summary

This proposal adds support for automatically copying template-associated assets (fonts, images, logos, etc.) when using custom Typst templates via `typst_template` configuration.

## Problem

Currently, when using custom Typst templates, the template file itself (`_template.typ`) is copied to the output directory, but assets referenced by the template are **not** automatically copied, causing compilation failures.

## Proposed Solution

Add automatic asset copying functionality with two modes:

### 1. Automatic Directory Copy (Default)
When `typst_template` is configured, automatically copy the entire template directory:

```python
# conf.py
typst_template = "_templates/corporate/template.typ"
# → Copies entire _templates/corporate/ directory
```

### 2. Explicit Asset Specification
Use `typst_template_assets` for granular control:

```python
typst_template = "_templates/template.typ"
typst_template_assets = [
    "_templates/logo.png",
    "_templates/fonts/*.otf"  # Glob patterns supported
]
```

## Key Features

- ✅ Backward compatible (no impact on existing projects)
- ✅ Follows existing `copy_image_files()` pattern
- ✅ Supports glob patterns for flexible asset selection
- ✅ Can be disabled with empty list: `typst_template_assets = []`
- ✅ Only affects local templates (not Typst Universe packages)

## Proposal Contents

- **[proposal.md](openspec/changes/add-template-assets/proposal.md)**: Problem statement, use cases, scope
- **[design.md](openspec/changes/add-template-assets/design.md)**: Implementation options, architecture, edge cases
- **[specs/template-system/spec.md](openspec/changes/add-template-assets/specs/template-system/spec.md)**: Requirements and scenarios
- **[tasks.md](openspec/changes/add-template-assets/tasks.md)**: Detailed implementation tasks (6 phases, 11-17 hours)

## Validation

```bash
openspec validate add-template-assets --strict
# ✅ Change 'add-template-assets' is valid
```

## Related

Addresses #75

---

📋 **Note**: This is a **Proposal PR** that documents the planned change. The actual implementation will be done in a separate PR after this proposal is reviewed and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)