### PR TITLE
fix: improve language switcher URL generation

### DIFF
--- a/docs/source/_templates/language-switcher.html
+++ b/docs/source/_templates/language-switcher.html
@@ -7,7 +7,10 @@
       {% if language == lang_code %}
       <span>{{ lang_name }}</span>
       {% else %}
-      <a href="{{ pathto('index', 1)|replace('/' + language + '/', '/' + lang_code + '/') }}">{{ lang_name }}</a>
+      {# Generate language switch URL by replacing the language code in the current page path #}
+      {% set current_page = pagename + '.html' if pagename else 'index.html' %}
+      {% set base_path = pathto_root %}
+      <a href="{{ base_path }}../{{ lang_code }}/{{ current_page }}">{{ lang_name }}</a>
       {% endif %}
     </li>
     {% endfor %}


### PR DESCRIPTION
## Problem

After merging #88, the language switcher links were not working correctly on subpages. When switching from a subpage (e.g., ) to another language, the generated URLs were incorrect, making the English version inaccessible.

## Root Cause

The language switcher template was using  to generate URLs, which created paths relative to the index page rather than the current page. This approach failed on subpages because the relative path calculation was incorrect.

## Solution

Updated the language switcher template to use:
-  to get the current page name
-  to construct proper relative paths
- Direct path construction: `../${lang_code}/${current_page}`

This generates correct relative URLs from any page:
- From `/en/index.html` → `../ja/index.html`
- From `/en/installation.html` → `../ja/installation.html`
- From `/en/user_guide/builders.html` → `../../ja/user_guide/builders.html`

## Testing

✅ Built multi-language docs locally and verified:
- Language switcher works from index page
- Language switcher works from subpages (installation, quickstart, etc.)
- Language switcher works from nested pages (user_guide/*, examples/*)
- All generated links use correct relative paths

## Related

- Fixes issue introduced in #88
- Resolves accessibility problem with English documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)