### PR TITLE
fix: prevent language redirect loop using session storage

### DIFF
--- a/docs/build_multilang.py
+++ b/docs/build_multilang.py
@@ -76,12 +76,20 @@ def create_redirect_page():
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./en/index.html">
     <link rel="canonical" href="https://yusabo90002.github.io/typsphinx/en/index.html">
     <title>typsphinx Documentation</title>
     <script>
-      // Detect browser language and redirect accordingly
+      // Smart language detection with session storage
       (function() {
+        // Check if user already visited a language page in this session
+        var visitedLang = sessionStorage.getItem('typsphinx_lang');
+
+        // If user explicitly visited a language page, don't redirect again
+        if (visitedLang) {
+          return;
+        }
+
+        // Otherwise, detect browser language and redirect
         var lang = navigator.language || navigator.userLanguage;
         if (lang && lang.startsWith('ja')) {
           window.location.href = './ja/index.html';

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,11 @@
+{% extends "!page.html" %}
+
+{% block extrahead %}
+{{ super() }}
+{# Mark current language in session storage to prevent unwanted redirects #}
+<script>
+  (function() {
+    sessionStorage.setItem('typsphinx_lang', '{{ language }}');
+  })();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Problem

After merging PR #88 (multi-language documentation), users reported that:
1. Clicking on the English version link would redirect to Japanese version
2. The root `index.html` would always redirect based on browser language settings
3. This made it impossible to access the English version for users with Japanese browser locale

## Root Cause

The redirect page (`index.html`) used only browser language detection without considering user's explicit language choice. Even when users clicked on "English Documentation", the redirect logic would immediately send them back to the Japanese version.

## Solution

Implemented a session storage-based solution:

1. **Session tracking**: Each language page now sets `sessionStorage.setItem('typsphinx_lang', '<lang>')` when loaded
2. **Smart redirect**: The root `index.html` checks session storage before auto-redirecting
3. **User choice respect**: If a language has been visited in the session, auto-redirect is skipped

## Changes

- `docs/build_multilang.py`: Updated redirect page logic to check session storage
- `docs/source/_templates/page.html`: New template to inject session storage tracking on all pages

## Behavior

### Before
1. User visits root → Redirected to Japanese (browser locale)
2. User clicks "English" link → Immediately redirected back to Japanese
3. User cannot access English version

### After
1. User visits root → Redirected to Japanese (browser locale) 
2. Japanese page loads → Sets `sessionStorage.typsphinx_lang = 'ja'`
3. User clicks language switcher "English" → Navigates to English version
4. English page loads → Sets `sessionStorage.typsphinx_lang = 'en'`
5. User can freely navigate between languages without unwanted redirects

## Testing

Tested locally with `uv run python docs/build_multilang.py` and verified:
- ✅ First visit redirects based on browser language
- ✅ Language switcher works correctly
- ✅ No redirect loop occurs
- ✅ Users can access both English and Japanese versions

Fixes the issue reported where English version was inaccessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)