### PR TITLE
fix: render captioned tables as figure(kind: table) instead of broken heading

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -161,6 +161,128 @@ def test_table_conversion(simple_document, mock_builder):
     assert "Cell 2" in output
 
 
+def _build_table(caption_children=None):
+    """
+    Build a 2x2 table doctree like the ``.. table::`` directive produces.
+
+    Args:
+        caption_children: Optional list of inline nodes for the table caption.
+            The directive stores the caption as a ``title`` child of ``table``.
+
+    Returns:
+        The table node
+    """
+    table = nodes.table()
+
+    if caption_children is not None:
+        title = nodes.title()
+        for child in caption_children:
+            title += child
+        table += title
+
+    tgroup = nodes.tgroup(cols=2)
+    tgroup += nodes.colspec(colwidth=1)
+    tgroup += nodes.colspec(colwidth=1)
+
+    thead = nodes.thead()
+    header_row = nodes.row()
+    for text in ("Header 1", "Header 2"):
+        entry = nodes.entry()
+        entry += nodes.paragraph(text=text)
+        header_row += entry
+    thead += header_row
+    tgroup += thead
+
+    tbody = nodes.tbody()
+    body_row = nodes.row()
+    for text in ("Cell 1", "Cell 2"):
+        entry = nodes.entry()
+        entry += nodes.paragraph(text=text)
+        body_row += entry
+    tbody += body_row
+    tgroup += tbody
+
+    table += tgroup
+    return table
+
+
+def test_captioned_table_renders_as_figure(simple_document, mock_builder):
+    """Test that a table caption becomes figure(table(...), caption: ...)."""
+    from typsphinx.translator import TypstTranslator
+
+    translator = TypstTranslator(simple_document, mock_builder)
+
+    table = _build_table(caption_children=[nodes.Text("My caption")])
+    table.walkabout(translator)
+
+    output = translator.astext()
+
+    # The caption must not be rendered as a section heading
+    assert "heading(" not in output
+
+    # The table must be wrapped in a figure with the caption and table kind
+    # so that captioned tables get "Table N" numbering
+    assert "figure(" in output
+    assert 'caption: {text("My caption")}' in output
+    assert "kind: table" in output
+
+    # The table content itself must still be intact
+    assert "table(" in output
+    assert 'text("Header 1")' in output
+    assert 'text("Cell 1")' in output
+
+
+def test_table_caption_supports_inline_markup(simple_document, mock_builder):
+    """Test that inline markup in a table caption is preserved."""
+    from typsphinx.translator import TypstTranslator
+
+    translator = TypstTranslator(simple_document, mock_builder)
+
+    emphasis = nodes.emphasis()
+    emphasis += nodes.Text("important")
+    table = _build_table(caption_children=[nodes.Text("A very "), emphasis])
+    table.walkabout(translator)
+
+    output = translator.astext()
+
+    assert "heading(" not in output
+    assert "figure(" in output
+    assert 'text("A very ")' in output
+    assert 'emph({text("important")})' in output
+
+
+def test_table_caption_not_lost_after_previous_table(simple_document, mock_builder):
+    """Test that a caption is not swallowed by a previous table's cell buffer."""
+    from typsphinx.translator import TypstTranslator
+
+    translator = TypstTranslator(simple_document, mock_builder)
+
+    # First an uncaptioned table: this used to leave a stale
+    # table_cell_content attribute behind, which silently swallowed
+    # the caption of any following table.
+    _build_table().walkabout(translator)
+    _build_table(caption_children=[nodes.Text("Second caption")]).walkabout(translator)
+
+    output = translator.astext()
+
+    assert 'caption: {text("Second caption")}' in output
+    # The caption must appear exactly once (not leak into a table cell)
+    assert output.count('text("Second caption")') == 1
+
+
+def test_uncaptioned_table_not_wrapped_in_figure(simple_document, mock_builder):
+    """Test that tables without a caption are not wrapped in a figure."""
+    from typsphinx.translator import TypstTranslator
+
+    translator = TypstTranslator(simple_document, mock_builder)
+
+    _build_table().walkabout(translator)
+
+    output = translator.astext()
+    assert "figure(" not in output
+    assert "table(" in output
+
+
 def test_unknown_visit_handles_unknown_nodes(simple_document, mock_builder):
     """Test that unknown_visit is called for unknown nodes."""
     from typsphinx.translator import TypstTranslator

--- a/typsphinx/translator.py
+++ b/typsphinx/translator.py
@@ -42,6 +42,11 @@ class TypstTranslator(SphinxTranslator):
         self.in_table = False
         self.in_thead = False  # Track if currently in table header
         self.in_caption = False
+
+        # Table caption state: the ``.. table:: Caption`` directive stores
+        # its caption as a ``title`` child of the ``table`` node
+        self.table_caption: Optional[str] = None
+        self._in_table_caption = False
         self.list_stack = []  # Track list nesting: 'bullet' or 'enumerated'
 
         # Figure-specific state
@@ -183,6 +188,24 @@ class TypstTranslator(SphinxTranslator):
         Args:
             node: The title node
         """
+        if self.in_table:
+            # A title inside a table is the table caption (from the
+            # ``.. table:: Caption`` directive), not a heading.  Buffer
+            # its children (which may carry inline markup) and emit the
+            # caption as part of a figure() wrapper in depart_table.
+            self._in_table_caption = True
+            # add_text() routes output here while in_table is set
+            self.table_cell_content = []
+            self._caption_saved_list_state = (
+                self.in_list_item,
+                self.list_item_needs_separator,
+            )
+            # The caption is emitted as a {} code block, so children are
+            # newline-separated statements (same handling as list items)
+            self.in_list_item = True
+            self.list_item_needs_separator = False
+            return
+
         # Use heading() function (no # prefix in code mode)
         self.add_text(f"heading(level: {self.section_level}, ")
 
@@ -195,6 +218,17 @@ class TypstTranslator(SphinxTranslator):
         Args:
             node: The title node
         """
+        if self._in_table_caption:
+            # Harvest the buffered caption for depart_table
+            self.table_caption = "".join(self.table_cell_content).strip()
+            self.table_cell_content = []
+            (
+                self.in_list_item,
+                self.list_item_needs_separator,
+            ) = self._caption_saved_list_state
+            self._in_table_caption = False
+            return
+
         # Close heading() function
         self.add_text(")\n\n")
 
@@ -1197,6 +1231,7 @@ class TypstTranslator(SphinxTranslator):
         self.in_table = True
         self.table_cells = []  # Store cells for table generation
         self.table_colcount = 0  # Track number of columns
+        self.table_caption = None  # Set by depart_title for captioned tables
 
     def _format_table_cell(self, cell: dict, indent: str = "  ") -> str:
         """
@@ -1236,8 +1271,7 @@ class TypstTranslator(SphinxTranslator):
         """
         # Generate Typst table() syntax (no # prefix in unified code mode)
         if self.table_colcount > 0:
-            # Use self.body.append directly to avoid routing to table_cell_content
-            self.body.append(f"table(\n  columns: {self.table_colcount},\n")
+            parts = [f"table(\n  columns: {self.table_colcount},\n"]
 
             # Separate header cells from body cells
             header_cells = [cell for cell in self.table_cells if cell.get("is_header")]
@@ -1247,20 +1281,38 @@ class TypstTranslator(SphinxTranslator):
 
             # Add header cells with table.header() wrapper
             if header_cells:
-                self.body.append("  table.header(\n")
+                parts.append("  table.header(\n")
                 for cell in header_cells:
-                    self.body.append(self._format_table_cell(cell, indent="    "))
-                self.body.append("  ),\n")
+                    parts.append(self._format_table_cell(cell, indent="    "))
+                parts.append("  ),\n")
 
             # Add body cells
             for cell in body_cells:
-                self.body.append(self._format_table_cell(cell, indent="  "))
+                parts.append(self._format_table_cell(cell, indent="  "))
 
-            self.body.append(")\n\n")
+            parts.append(")")
+            table_code = "".join(parts)
+
+            # Use self.body.append directly to avoid routing to table_cell_content
+            if self.table_caption is not None:
+                # Captioned tables are wrapped in a figure so they get
+                # "Table N" numbering
+                self.body.append(
+                    f"figure(\n{table_code},\n"
+                    f"  caption: {{{self.table_caption}}},\n"
+                    f"  kind: table\n)\n\n"
+                )
+            else:
+                self.body.append(f"{table_code}\n\n")
 
         self.in_table = False
         self.table_cells = []
         self.table_colcount = 0
+        self.table_caption = None
+        # Drop the per-cell buffer so stale state cannot swallow output
+        # (e.g. the caption) of a following table
+        if hasattr(self, "table_cell_content"):
+            del self.table_cell_content
 
     def visit_tgroup(self, node: nodes.tgroup) -> None:
         """


### PR DESCRIPTION
I recently migrated the build workflow for a complex document from rst -> latex -> pdf to using Typst with this tool. Doing so uncovered several issues in `typsphinx` that I had to workaround.

I have a bunch of branches with fixes lined up - here's the first of them.

## Issue

A docutils table caption (from the `.. table:: Caption` directive) is stored
as a `title` child of the `table` node. The generic `visit_title` fired for
it and emitted a spurious `heading(level: N, ...)` before the table. Worse,
if a previous table had left a stale `table_cell_content` attribute behind,
`add_text()` routed the caption text into that dead buffer and the caption
disappeared entirely.

## Example input

```rst
.. table:: First caption

   ===== =====
   A     B
   ===== =====
   1     2
   ===== =====
```

## Broken output (before)

```typst
heading(level: 1, text("First caption"))

table(
  columns: 2,
  ...
)
```

(and for any table after the first one, the caption vanished completely)

## Corrected output (after)

```typst
figure(
table(
  columns: 2,
  ...
),
  caption: {text("First caption")},
  kind: table
)
```

## Change

`visit_title`/`depart_title` now buffer the caption (preserving inline
markup) when inside a table; `depart_table` wraps captioned tables in
`figure(table(...), caption: {...}, kind: table)` so they get "Table N"
numbering, and deletes the per-cell buffer so stale state cannot leak
into the next table.
