### PR TITLE
docs: コードベースマップを追加 (.planning/codebase/)

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,304 @@
+<!-- refreshed: 2026-07-04 -->
+# Architecture
+
+**Analysis Date:** 2026-07-04
+
+## System Overview
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Sphinx Entry Point                        │
+│  typsphinx.__init__.setup() registers builders              │
+└─────────────────────────────────────────────────────────────┘
+         │
+         ├─────────────────────┬─────────────────────┐
+         ▼                     ▼                     ▼
+┌──────────────────────┐ ┌──────────────────────┐ ┌─────────────┐
+│   TypstBuilder       │ │ TypstPDFBuilder      │ │   Config    │
+│  `builder.py`        │ │  (extends TypstB.)   │ │ `__init__.py`│
+│  Orchestrator        │ │ PDF compilation      │ └─────────────┘
+└─────────┬────────────┘ └──────────┬───────────┘
+          │                         │
+          └──────────┬──────────────┘
+                     │
+                     ▼
+          ┌──────────────────────┐
+          │   TypstWriter        │
+          │   `writer.py`        │
+          │ Translation & Templ. │
+          └──────┬───────────────┘
+                 │
+                 ▼
+        ┌────────────────────────┐
+        │  TypstTranslator       │
+        │  `translator.py`       │
+        │  Visitor pattern for   │
+        │  docutils node->Typst  │
+        └────────┬───────────────┘
+                 │
+                 ▼
+        ┌────────────────────────┐
+        │  TemplateEngine        │
+        │  `template_engine.py`  │
+        │  Template loading &    │
+        │  parameter mapping     │
+        └────────┬───────────────┘
+                 │
+                 ▼
+        ┌────────────────────────┐
+        │  PDF Compilation       │
+        │  `pdf.py`              │
+        │  typst-py wrapper      │
+        └────────────────────────┘
+```
+
+## Component Responsibilities
+
+| Component | Responsibility | File |
+|-----------|----------------|------|
+| TypstBuilder | Orchestrate document translation; manage build lifecycle; coordinate writer and asset copying | `typsphinx/builder.py` |
+| TypstPDFBuilder | Extend TypstBuilder to compile .typ files to PDF using typst-py | `typsphinx/builder.py` |
+| TypstWriter | Create translator instances; coordinate template application; output Typst markup | `typsphinx/writer.py` |
+| TypstTranslator | Visit docutils nodes and generate Typst markup code; manage translation state | `typsphinx/translator.py` |
+| TemplateEngine | Load default/custom templates; map Sphinx metadata to template parameters; render final output | `typsphinx/template_engine.py` |
+| PDF Utilities | Compile Typst markup to PDF using typst-py package; error handling | `typsphinx/pdf.py` |
+
+## Pattern Overview
+
+**Overall:** Sphinx Builder Extension with Visitor Pattern Translation
+
+**Key Characteristics:**
+- Implements Sphinx Builder interface (`sphinx.builders.Builder`)
+- Uses visitor pattern (docutils) to traverse and translate document trees
+- Separates concerns: building, writing, translating, templating, compilation
+- Supports two output formats: Typst markup (.typ) and PDF (.pdf)
+- Handles both master documents (with template) and included documents (#include())
+
+## Layers
+
+**Sphinx Integration Layer:**
+- Purpose: Register with Sphinx and hook into build process
+- Location: `typsphinx/__init__.py`
+- Contains: Extension setup, builder registration, config value registration
+- Depends on: sphinx.application, sphinx.builders
+- Used by: Sphinx application loader
+
+**Build Orchestration Layer:**
+- Purpose: Manage build lifecycle and coordinate document processing
+- Location: `typsphinx/builder.py` (TypstBuilder, TypstPDFBuilder classes)
+- Contains: Document discovery, writer setup, output directory management, asset copying (images, templates), PDF compilation orchestration
+- Depends on: sphinx.builders.Builder, docutils.nodes
+- Used by: Sphinx build system
+
+**Document Translation Layer:**
+- Purpose: Convert Sphinx docutils document trees to Typst markup
+- Location: `typsphinx/writer.py`, `typsphinx/translator.py`
+- Contains: 
+  - Writer: orchestrates translation, applies templates, manages document/master distinction
+  - Translator: stateful visitor that walks doctree and generates Typst code
+- Depends on: docutils.nodes, sphinx.util.docutils.SphinxTranslator
+- Used by: TypstBuilder during write phase
+
+**Template & Configuration Layer:**
+- Purpose: Handle template loading, parameter mapping, and document rendering
+- Location: `typsphinx/template_engine.py`
+- Contains: Template resolution (custom → search paths → default), Sphinx metadata mapping, Typst Universe package support, template rendering with parameters
+- Depends on: pathlib, typing
+- Used by: TypstWriter for document rendering
+
+**PDF Compilation Layer:**
+- Purpose: Compile generated Typst markup to PDF
+- Location: `typsphinx/pdf.py`
+- Contains: Typst availability checking, PDF compilation via typst-py, error handling and parsing
+- Depends on: typst package, logging, tempfile
+- Used by: TypstPDFBuilder.finish()
+
+## Data Flow
+
+### Primary Request Path: Document Translation
+
+1. **Build Initiation** (`typsphinx/__init__.py:setup()`)
+   - Sphinx loads extension via entry point
+   - Registers TypstBuilder and TypstPDFBuilder
+   - Registers configuration values (typst_documents, typst_template, typst_use_mitex, etc.)
+
+2. **Build Phase: Preparation** (`typsphinx/builder.py:TypstBuilder.prepare_writing()`)
+   - Creates TypstWriter instance
+   - Writes template file (_template.typ) to output directory for master documents to import
+   - Template file uses TemplateEngine to load and render template with metadata
+
+3. **Build Phase: Document Writing** (`typsphinx/builder.py:TypstBuilder.write()`)
+   - Iterates over all documents to build
+   - For each document: calls `env.get_doctree()` to get document tree (preserving toctree nodes)
+   - Applies post-transforms to doctree
+   - Calls `write_doc()` for each document
+
+4. **Single Document Translation** (`typsphinx/builder.py:TypstBuilder.write_doc()`)
+   - Gets doctree for document
+   - Calls `self.writer.translate()` to translate to Typst
+   - Saves output to .typ file in output directory (preserving source directory structure)
+   - Collects images via `post_process_images()`
+
+5. **Translation to Typst Markup** (`typsphinx/writer.py:TypstWriter.translate()`)
+   - Creates TypstTranslator with document and builder context
+   - Calls `document.walkabout(visitor)` to visit all nodes
+   - Translator generates body content as Typst markup
+   - For included documents (not in typst_documents): wraps body in essential imports, returns
+   - For master documents (in typst_documents):
+     - Creates TemplateEngine with configuration
+     - Gathers Sphinx metadata (project, author, release, copyright, custom elements)
+     - Maps parameters using TemplateEngine.map_parameters()
+     - Extracts toctree options
+     - Renders with template: `template_engine.render(params, body, template_file="_template.typ")`
+
+6. **Node Translation** (`typsphinx/translator.py:TypstTranslator` - visitor methods)
+   - Maintains state: section_level, in_figure, in_table, in_paragraph, list_stack, etc.
+   - Visits each docutils node type (title, paragraph, emphasis, code, table, etc.)
+   - Generates Typst function calls and markup
+   - All content wrapped in code mode block `#{...}` for unified syntax
+   - Uses Typst functions: heading(), par(), text(), emph(), etc.
+
+7. **Finish Phase: Asset Copying** (`typsphinx/builder.py:TypstBuilder.finish()`)
+   - Copies image files from source to output (preserving paths)
+   - Copies template assets (fonts, logos, etc.) if custom template used
+   - Logs completion
+
+### Secondary Path: PDF Generation (TypstPDFBuilder only)
+
+1. **Override write_doc()** (`typsphinx/builder.py:TypstPDFBuilder.write_doc()`)
+   - Generates .typ file (same as parent TypstBuilder)
+   - Does not generate .pdf yet (deferred to finish())
+
+2. **PDF Compilation** (`typsphinx/builder.py:TypstPDFBuilder.finish()`)
+   - Calls parent `super().finish()` to copy assets
+   - For each master document (typst_documents):
+     - Reads .typ file from output directory
+     - Calls `compile_typst_to_pdf()` with content and root_dir
+     - Writes PDF to output directory with same docname
+     - Logs success or error
+
+3. **Typst Compilation** (`typsphinx/pdf.py:compile_typst_to_pdf()`)
+   - Validates typst package is available
+   - Writes Typst content to temporary file (in root_dir if provided)
+   - Calls `typst.compile(temp_file, root=root_dir)` → returns PDF bytes
+   - Cleans up temporary file
+   - Handles and parses errors via `_parse_typst_error()`
+
+**State Management:**
+- Builder maintains current docname, outdir, srcdir
+- Writer maintains builder reference and document state
+- Translator maintains extensive state: section level, context flags (in_table, in_figure, in_paragraph, etc.), list nesting stack, buffered content
+- TemplateEngine is stateless (holds config, loads templates on demand)
+
+## Key Abstractions
+
+**Visitor Pattern (Translator):**
+- Purpose: Stateful traversal of docutils document trees
+- Examples: `visit_paragraph()`, `visit_title()`, `visit_emphasis()`, etc.
+- Pattern: Each node type has visit_* and depart_* methods managing state and output
+- Located in: `typsphinx/translator.py` (extends `sphinx.util.docutils.SphinxTranslator`)
+
+**Master vs. Included Documents:**
+- Purpose: Different output for different document roles in typst_documents config
+- Master documents: full template wrapping (headers, imports, layout)
+- Included documents: minimal imports only (included via #include() in master)
+- Implementation: `typsphinx/writer.py:TypstWriter._is_master_document()`
+- Decision point: `typsphinx/writer.py:TypstWriter.translate()` branches based on master status
+
+**Template Resolution Chain:**
+- Purpose: Flexible template discovery with fallback to default
+- Priority: explicit template_path → search_paths → default bundled template
+- Implementation: `typsphinx/template_engine.py:TemplateEngine.load_template()`
+- Supports: custom paths, directory search, Typst Universe packages (@preview/*)
+
+**Typst Universe Package Support:**
+- Purpose: Use external Typst templates from @preview namespace
+- Config options: typst_package (package spec), typst_template_function (template function name), typst_package_imports (specific imports)
+- When active: skips custom template file writing, relies on Typst package instead
+- Location: checked throughout builder and writer
+
+## Entry Points
+
+**Sphinx Extension Entry Point:**
+- Location: `typsphinx/__init__.py:setup(app: Sphinx) -> Dict[str, Any]`
+- Triggers: When Sphinx loads extension (via entry point in pyproject.toml)
+- Responsibilities: Register builders, register config values
+- Returns: Metadata dict with version, parallel_read_safe, parallel_write_safe
+
+**Build Entry Points:**
+- TypstBuilder.init(): Initial builder setup
+- TypstBuilder.get_outdated_docs(): Rebuild all documents (simple strategy)
+- TypstBuilder.prepare_writing(): Setup before build
+- TypstBuilder.write(): Main build loop
+- TypstBuilder.finish(): Post-build asset copying
+
+**Build Format Registration:**
+- `sphinx.builders:typst` → TypstBuilder
+- `sphinx.builders:typstpdf` → TypstPDFBuilder
+- Invoked via `sphinx-build -b typst` or `sphinx-build -b typstpdf`
+
+## Architectural Constraints
+
+- **Sphinx Compatibility:** Must inherit from `sphinx.builders.Builder` and follow Sphinx build lifecycle
+- **Threading:** `allow_parallel = True` on builders; stateless design where possible (state in builder/writer/translator instances)
+- **Global State:** Minimal; each document gets new TypstTranslator instance with fresh state
+- **Circular Imports:** Avoided via careful layering (builder imports writer, writer imports translator and template_engine, translator doesn't import builder)
+- **Python Version:** Must support Python 3.9+ (declared in pyproject.toml)
+- **Dependencies:** Core requires sphinx ≥5.0, docutils ≥0.18, typst ≥0.14.1; PDF requires typst-py
+- **Template File Format:** Typst markup with parameter injection (not Jinja2 or Python templating)
+- **Code Mode Design:** All translation output uses Typst code mode `#{...}` (no hybrid markup/code)
+
+## Anti-Patterns
+
+### State Mutation in Visitor During Traversal
+
+**What happens:** Translator state (section_level, in_table, etc.) is modified during node visitation without proper cleanup
+
+**Why it's wrong:** If visitor pattern traversal is interrupted or reordered, state can become inconsistent, leading to malformed output
+
+**Do this instead:** Always pair visit_* and depart_* methods. Increment in visit_*, decrement in depart_. Use try-finally or context managers if cleanup is critical. `typsphinx/translator.py` implements this correctly (e.g., `visit_section` increments, `depart_section` decrements).
+
+### Mixing Translation Logic with Template Rendering
+
+**What happens:** Earlier code versions tried to apply templates during translation
+
+**Why it's wrong:** Couples node translation to document role (master/included), makes testing harder, reduces reusability
+
+**Do this instead:** Translate to plain Typst markup first, then apply template in Writer layer. `typsphinx/writer.py:TypstWriter.translate()` does this correctly—generates body content first, then wraps in template only for master documents.
+
+### Hardcoded File Paths Without Preservation
+
+**What happens:** Builder outputs flat directory structure, losing source directory nesting
+
+**Why it's wrong:** Multi-level documentation (chapters/sections as subdirectories) produces confusing flat output
+
+**Do this instead:** Preserve source directory structure in output. `typsphinx/builder.py:TypstBuilder.write_doc()` uses `path.join(self.outdir, docname + self.out_suffix)` where docname includes path (e.g., "chapter1/section1"), and calls `ensuredir()` to create nested directories.
+
+## Error Handling
+
+**Strategy:** Graceful degradation with logging; critical errors raise exceptions
+
+**Patterns:**
+- File not found (images, templates): Log warning, continue (don't break build)
+- Template loading: Fallback to default template if custom not found
+- Typst compilation: Catch exception, parse error details, raise TypstCompilationError with context
+- Invalid nodes: Log debug message, skip or output placeholder
+
+**Error Types:**
+- `TypstCompilationError` (from pdf.py): Wraps typst-py exceptions with context
+- Standard exceptions: TypeError, ValueError for config validation
+- Sphinx warnings: Logged via sphinx.util.logging
+
+## Cross-Cutting Concerns
+
+**Logging:** Via `sphinx.util.logging.getLogger(__name__)` in each module; uses Sphinx's logger for consistency and control
+
+**Validation:** Config values validated in setup() and builder init(); docutils nodes assumed valid (Sphinx guarantees)
+
+**Image/Asset Handling:** Tracked during translation, copied in finish() phase; preserves relative paths
+
+**Configuration:** Registered in setup(), accessed via builder.config; supports custom values (typst_documents, typst_template, typst_use_mitex, typst_elements, etc.)
+
+---
+
+*Architecture analysis: 2026-07-04*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,166 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-07-04
+
+## Tech Debt
+
+**Hardcoded Typst Package Versions:**
+- Issue: Critical external dependency versions are hardcoded in two locations with no configuration option to customize them
+- Files: `typsphinx/writer.py` (lines 94-97), `typsphinx/template_engine.py` (lines 313-316)
+- Versions hardcoded:
+  - `@preview/codly:1.3.0`
+  - `@preview/codly-languages:0.1.1`
+  - `@preview/mitex:0.2.4`
+  - `@preview/gentle-clues:1.2.0`
+- Impact: When Typst Universe updates these packages with breaking changes, builds fail with no way to override versions without modifying source code. Users cannot use newer package versions even if compatible.
+- Fix approach: Extract hardcoded versions to configuration values in `typsphinx/__init__.py` under `app.add_config_value()` for `typst_package_versions` dict. Modify `writer.py` and `template_engine.py` to reference these configurable values.
+
+**Inefficient Document Rebuild Strategy:**
+- Issue: `TypstBuilder.get_outdated_docs()` (line 57 in `builder.py`) always returns all documents for rebuilding instead of tracking actual changes
+- Files: `typsphinx/builder.py:48-58`
+- Impact: Every build processes all documents regardless of changes, wasting CPU/IO time. Scales poorly with large documentation sets (hundreds of documents). Makes incremental builds impossible.
+- Fix approach: Implement proper rebuild tracking by storing document timestamps or hashes. Compare source modification times against output file timestamps using `os.path.getmtime()`.
+
+**Broad Exception Handling:**
+- Issue: Multiple locations catch generic `Exception` instead of specific exception types
+- Files:
+  - `typsphinx/builder.py:280` (image copying), `typsphinx/builder.py:377` (asset copying), `typsphinx/builder.py:453` (single asset copying), `typsphinx/builder.py:566` (PDF compilation)
+  - `typsphinx/pdf.py:102` (version detection), `typsphinx/pdf.py:152` (compilation), `typsphinx/pdf.py:168` (cleanup)
+- Impact: Masks underlying errors and makes debugging difficult. Silent failures could cause incorrect behavior (e.g., cleanup errors silently ignored).
+- Fix approach: Catch specific exceptions: `OSError` for file operations, `ImportError` for module imports, `ChildProcessError` for compilation.
+
+## Known Issues
+
+**Fragile Document Wrapper Detection:**
+- Issue: `writer.py:75-80` includes WORKAROUND comment noting that `visit_document()` may not be called, requiring manual `#{...}` wrapping detection
+- Files: `typsphinx/writer.py:60-105`
+- Symptoms: Document body may be missing code mode wrapper in certain Sphinx configurations
+- Trigger: Non-standard document tree structures where root `document` node doesn't invoke visitor method
+- Workaround: Code checks `body.startswith("#{")` and `body.endswith("}")`; adds wrappers if missing
+- Risk: This fragile workaround could fail silently for edge cases, producing invalid Typst syntax
+
+**Nested Image Path Calculation:**
+- Issue: Complex relative path computation for nested documents (changelog #69, commit 9bb0045)
+- Files: `typsphinx/translator.py` (contains `_compute_relative_image_path()` and related logic)
+- Trigger: Documents in subdirectories referencing images at different levels
+- Risk: Path calculation could fail for unusual nested structures or symlinks. Manual path computation is error-prone compared to using `pathlib.Path.relative_to()`.
+
+**Template File Write-Once Pattern:**
+- Issue: `_write_template_file()` only writes template once during `prepare_writing()`, not refreshed if config changes
+- Files: `typsphinx/builder.py:201-245`
+- Impact: If Sphinx config changes mid-build or between incremental builds, cached template file could be stale
+- Risk: Produces inconsistent output across multiple builds with different configurations
+
+## Performance Bottlenecks
+
+**Full Document Tree Traversal on Every Build:**
+- Problem: `get_outdated_docs()` always yields all documents in `self.env.found_docs` without any change tracking
+- Files: `typsphinx/builder.py:48-58`
+- Cause: No comparison between source and output modification times
+- Improvement path: Implement change detection using `os.path.getmtime()` comparison or store modification checksums in `self.env.temp_data`
+
+**Template Compilation Without Caching:**
+- Problem: Template content re-loaded and re-processed on every document write
+- Files: `typsphinx/template_engine.py:107-154` (load_template called each time from writer)
+- Cause: No memoization of template content
+- Improvement path: Cache template content in `TemplateEngine.__init__()` or `self.template_cache` dict
+
+## Fragile Areas
+
+**TypstTranslator State Management:**
+- Files: `typsphinx/translator.py:19-92`
+- Why fragile: 
+  - 2679-line file with 20+ state variables tracking nested contexts
+  - State variables include: `in_figure`, `in_table`, `in_thead`, `list_stack`, `figure_content`, `code_block_caption`, `in_paragraph`, `in_list_item`, `in_literal_block`, `is_first_list_item`, `_in_reference_with_target`, `_in_markup_mode`, `in_desc_parameter`, etc.
+  - Each state variable adds complexity to visitor methods
+  - Nested list/table structures require careful state management
+- Safe modification: 
+  - Add state assertions at entry/exit of complex visitor methods: `assert not self.in_figure, "Already in figure"`
+  - Create context managers for state: `with self._table_context(): self.in_table = True; try: ... finally: self.in_table = False`
+  - Add logging for state transitions: `logger.debug(f"State: in_table={self.in_table}, in_thead={self.in_thead}")`
+- Test coverage: Existing 29 test files cover happy paths, but edge cases with deeply nested mixed content (tables in figures with lists) lack coverage
+
+**Image Path Resolution for Nested Documents:**
+- Files: `typsphinx/translator.py` (image handling logic), `typsphinx/builder.py:139-161`
+- Why fragile: 
+  - Manual path computation for relative/nested paths is error-prone
+  - Doesn't use Python's `pathlib.Path.relative_to()` for robustness
+  - Handles nested paths like `../images/diagram.png` which could break with symlinks
+- Safe modification: 
+  - Use `pathlib.Path` API instead of manual string manipulation
+  - Add unit tests for various path patterns: `./image.png`, `../image.png`, `../../image.png`, etc.
+  - Test with symlinked directories
+
+## Scaling Limits
+
+**Memory Usage with Large Documents:**
+- Current capacity: Tested with 37 test files covering basic to advanced scenarios
+- Limit: As document tree accumulates in `self.body[]` (translator.py line 37), memory usage grows linearly with content size
+- Scaling path: For massive documents (10k+ pages), consider streaming output to file instead of accumulating in memory
+
+**Build Time with Large Documentation Sets:**
+- Current capacity: Per-file processing appears linear, but with always-rebuild strategy, builds O(n) where n = all documents
+- Limit: Large projects with 500+ source files will rebuild everything even if 1 file changes
+- Scaling path: Implement change tracking in `get_outdated_docs()` to enable true incremental builds
+
+## Dependencies at Risk
+
+**Typst Version Coupling:**
+- Risk: Project requires `typst>=0.14.1` (pyproject.toml line 32), but hardcoded package versions may not be compatible with future Typst releases
+- Impact: When Typst 0.15 or later introduces breaking changes to package ecosystem, builds silently fail or produce incorrect output
+- Example: Issue #77 (empty URL links) required `typst>=0.14.1` update
+- Migration plan: 
+  - Make package versions configurable (see Tech Debt section)
+  - Add compatibility matrix testing for Typst versions 0.14.1, 0.15.x, 0.16.x
+  - Test against latest Typst Universe packages quarterly
+
+**External typst-py Package Availability:**
+- Risk: `typst` Python package (dependency from PyPI) might be abandoned, renamed, or moved to different maintainer
+- Impact: If typst-py becomes unavailable, `TypstPDFBuilder` cannot function
+- Current mitigation: Package is `>=0.14.1` (reasonable version constraint)
+- Recommendations: 
+  - Monitor typst-py repository for maintenance status
+  - Consider vendoring compilation logic if external package becomes unavailable
+  - Implement graceful fallback to suggest manual compilation if package missing
+
+**Sphinx Version Compatibility:**
+- Risk: Requires `sphinx>=5.0` (loose constraint allows 5.x, 6.x, 7.x)
+- Impact: Future Sphinx versions (8.x) may change builder APIs, breaking this extension
+- Current protection: Relies on SphinxTranslator base class which is relatively stable
+- Recommendations: Pin to tested ranges like `sphinx>=5.0,<8.0` and test against Sphinx 8 beta
+
+## Test Coverage Gaps
+
+**Hardcoded Package Version Resilience:**
+- What's not tested: Behavior when Typst packages update to new versions that introduce breaking changes
+- Files: `typsphinx/writer.py` (line 94-97), `typsphinx/template_engine.py` (lines 313-316)
+- Risk: Package updates silently break builds without clear error messages
+- Priority: **High** - impacts production builds
+
+**Incremental Build Correctness:**
+- What's not tested: Only rebuilding modified documents (not implemented yet)
+- Files: `typsphinx/builder.py:48-58`
+- Risk: Implementing change detection requires comprehensive testing to ensure no stale files are served
+- Priority: **High** - affects developer experience
+
+**Large Document Sets (500+ files):**
+- What's not tested: Build performance and memory usage with large projects
+- Files: `typsphinx/builder.py` (entire write pipeline)
+- Risk: Unknown performance characteristics could cause CI timeout failures
+- Priority: **Medium**
+
+**Edge Case State Management in Translator:**
+- What's not tested: Deeply nested combinations (e.g., table with figures inside list items inside another table)
+- Files: `typsphinx/translator.py` (lines 19-92)
+- Risk: State variables not initialized or cleared for unusual nesting patterns could produce invalid Typst
+- Priority: **Medium**
+
+**Path Resolution for Symlinked Directories:**
+- What's not tested: Image/template resolution when source directory contains symlinks
+- Files: `typsphinx/builder.py` (image copying), `typsphinx/template_engine.py` (template loading)
+- Risk: `os.path.join()` may not resolve correctly with symlinks; should use `os.path.realpath()`
+- Priority: **Low**
+
+---
+
+*Concerns audit: 2026-07-04*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,165 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-07-04
+
+## Naming Patterns
+
+**Files:**
+- Snake case with lowercase letters: `builder.py`, `translator.py`, `template_engine.py`, `pdf.py`, `writer.py`
+- Test files follow pattern: `test_*.py` (e.g., `test_builder.py`, `test_config.py`)
+- Template files in `typsphinx/templates/` directory (e.g., `base.typ`)
+
+**Classes:**
+- PascalCase: `TypstBuilder`, `TypstPDFBuilder`, `TypstTranslator`, `TypstWriter`, `TemplateEngine`, `TypstCompilationError`
+- Sphinx visitor pattern allowed exception: `SphinxTranslator`-derived classes use docutils visitor naming
+
+**Functions:**
+- Snake case: `setup()`, `get_outdated_docs()`, `get_target_uri()`, `prepare_writing()`, `write_doc()`, `astext()`, `add_text()`, `load_template()`
+- Private methods: Leading underscore: `_try_load_file()`, `_is_master_document()`, `_add_paragraph_separator()`, `_write_template_file()`, `_extract_error_info()`
+
+**Variables:**
+- Snake case: `docnames`, `section_level`, `figure_caption`, `table_cell_content`, `list_stack`
+- Boolean flags: Descriptive names: `in_figure`, `in_table`, `in_thead`, `in_caption`, `allow_parallel`
+- Module-level constants: UPPER_SNAKE_CASE: `DEFAULT_PARAMETER_MAPPING` in `typsphinx/template_engine.py` (line 35)
+
+**Types:**
+- Type hints use standard Python typing module
+- Union types: `Union[str, List[str], None]`
+- Optional types: `Optional[Dict[str, Any]]`
+- Generic containers: `List[str]`, `Dict[str, Any]`
+- Collection types: Use `dict`, `list` (not deprecated `Dict`, `List` for Python 3.9+ support)
+
+## Code Style
+
+**Formatting:**
+- Tool: `black` (version ≥ 23.0)
+- Line length: 88 characters
+- Configuration: See `pyproject.toml` lines 86-99
+- Target versions: Python 3.9, 3.10, 3.11, 3.12
+
+**Linting:**
+- Tool: `ruff` (version ≥ 0.1.0)
+- Configuration: See `pyproject.toml` lines 101-117
+- Selected rules: E, F, W, I, N, UP, B, A, C4, T20
+- Ignored rules include:
+  - E501: Line too long (handled by black)
+  - T201: print found (allowed in tests for debugging)
+  - N802: Function naming (docutils visitor pattern uses PascalCase)
+  - UP035, UP006, UP028: Python 3.9 compatibility exceptions
+
+**Type Checking:**
+- Tool: `mypy` (version ≥ 1.0)
+- Configuration: See `pyproject.toml` lines 119-132
+- Python version target: 3.9
+- Mypy overrides for `typsphinx.*` modules disable several checks for compatibility
+
+## Import Organization
+
+**Order (as seen in `typsphinx/builder.py`, `typsphinx/translator.py`):**
+1. Standard library imports: `import shutil`, `from os import path`, `from typing import ...`
+2. Third-party imports: `from docutils import nodes`, `from sphinx.builders import Builder`, `from sphinx.util import logging`
+3. Local imports: `from typsphinx.pdf import compile_typst_to_pdf`, `from typsphinx.writer import TypstWriter`
+
+**Style:**
+- Imports organized alphabetically within each group
+- Use explicit imports over wildcard imports
+- Module-level logging setup: `logger = logging.getLogger(__name__)` at module top
+
+**Path Aliases:**
+- Not detected in codebase; uses direct imports from `typsphinx.*` package
+
+## Error Handling
+
+**Patterns:**
+- Custom exceptions: Define exception classes extending `Exception` with docstrings
+  - Example: `TypstCompilationError` in `typsphinx/pdf.py` (lines 16-57)
+  - Provides message, typst_error reference, and source_location
+- Try/except blocks: Catch specific exceptions with appropriate logging
+  - Example: `typsphinx/builder.py` line 277-281 catches generic `Exception` when copying image files
+  - Example: `typsphinx/pdf.py` line 70-78 catches `ImportError` with `raise ... from e` pattern
+- Logger usage: `logger.warning()` for non-fatal issues, `logger.error()` for failures, `logger.debug()` for detailed info
+- Pre-condition checks: Check file existence before operations (e.g., `typsphinx/builder.py` line 268)
+
+**Exception Messages:**
+- Include context: File paths, configuration names, original error details
+- Multiple causes: Chain exceptions with `raise ... from e` (line 78 in pdf.py)
+- Structured error info: Exception attributes for programmatic access (TypstCompilationError attributes at line 23-27)
+
+## Logging
+
+**Framework:** `sphinx.util.logging`
+
+**Pattern:** 
+```python
+logger = logging.getLogger(__name__)
+```
+- Set at module level immediately after imports
+- Used throughout module methods
+
+**Usage Patterns:**
+- `logger.info()`: Build progress and general information (e.g., "preparing documents...")
+- `logger.warning()`: Non-fatal issues that don't stop the build (e.g., "Image file not found")
+- `logger.error()`: Fatal errors that stop processing (e.g., "Failed to compile")
+- `logger.debug()`: Detailed diagnostic information (e.g., "Loaded template from...")
+- Parameter `nonl=True`: Don't add newline for multi-part logging sequences (line 119 in builder.py)
+
+## Comments
+
+**When to Comment:**
+- Complex logic that isn't self-evident: State management transitions, workarounds
+- Requirement/Task/Issue references: Link to specifications
+- Example: `typsphinx/__init__.py` line 46: `# Task 13.4: Other configuration options (Requirement 8.6)`
+- Example: `typsphinx/writer.py` line 75-77: `# WORKAROUND: For some Sphinx documents, visit_document may not be called`
+
+**JSDoc/Type Documentation:**
+- Full docstrings for all public classes and functions
+- RST-style format with sections: summary, extended description, Args, Returns, Raises
+- Example: `typsphinx/builder.py` lines 37-42 (init method)
+- Parameter descriptions include type and semantic meaning
+- Requirement/Task references in docstrings when applicable
+
+**Inline Comments:**
+- Explain "why", not "what": Code already shows what it does
+- Reference issue/task numbers for context
+- Example: `typsphinx/builder.py` line 43-45: Explains why images dictionary tracks by URI
+
+## Function Design
+
+**Size:**
+- Methods typically 10-50 lines; longer methods break down complex operations
+- Example: `TypstBuilder.write()` is ~40 lines (lines 89-137)
+- Private helper methods extract single concerns
+
+**Parameters:**
+- Explicit naming over positional arguments
+- Type hints for all parameters
+- Default values for optional configuration
+- Example: `TemplateEngine.__init__()` uses 12 parameters with defaults (lines 41-51)
+
+**Return Values:**
+- Always type-hinted (including `None` for void functions)
+- Clear semantic meaning: `bool` for checks, `str` for content, `dict` for configuration
+- Example: `_is_master_document()` returns `bool` with clear True/False meaning (lines 36-58 in writer.py)
+- Iterator/generator types: `Iterator[str]` for `get_outdated_docs()` (line 48 in builder.py)
+
+## Module Design
+
+**Exports:**
+- Public API classes/functions at module level
+- Example: `typsphinx/__init__.py` exports `setup()` function as extension entry point
+- Private helpers use leading underscore
+
+**Barrel Files:**
+- Main package `typsphinx/__init__.py` handles Sphinx integration
+- Individual modules handle specific concerns (builder, translator, writer, template_engine, pdf)
+- No re-exports of public APIs through __all__
+
+**State Management:**
+- Class-level attributes for configuration (`TypstBuilder.name`, `TypstBuilder.format`, `TypstBuilder.out_suffix`)
+- Instance attributes initialized in `__init__()` and `init()` methods
+- Translator maintains state during tree traversal (section_level, list_stack, etc.)
+- State properly reset between independent operations
+
+---
+
+*Convention analysis: 2026-07-04*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,124 @@
+# External Integrations
+
+**Analysis Date:** 2026-07-04
+
+## APIs & External Services
+
+**Package Distribution:**
+- PyPI - Official Python package repository
+  - Distribution: `typsphinx` package
+  - Published via: `pypa/gh-action-pypi-publish` GitHub Action in release workflow
+
+**Typst Packages (imported in generated output):**
+- `@preview/mitex:0.2.4` - LaTeX math support in Typst documents (optional, controlled by `typst_use_mitex` config)
+- `@preview/codly:1.3.0` - Syntax highlighting for code blocks in Typst
+
+## Data Storage
+
+**Databases:**
+- None - Stateless extension; no persistent data storage
+
+**File Storage:**
+- Local filesystem only
+  - Input: Sphinx source files (reStructuredText/Markdown)
+  - Output: Generated `.typ` files in `_build/typst/` or PDFs in `_build/pdf/` (paths configurable via `typst_output_dir`)
+  - Template assets: `typsphinx/templates/` directory (packaged with distribution)
+
+**Caching:**
+- Sphinx's internal caching via `.doctrees/` (handled by Sphinx framework)
+- No external cache service
+
+## Authentication & Identity
+
+**Auth Provider:**
+- None - This is a library/extension, not an application
+- GitHub Actions: Uses `secrets.CODECOV_TOKEN`, `secrets.PYPI_API_TOKEN`, `secrets.TEST_PYPI_API_TOKEN` for CI/CD operations
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None at application level
+- Custom exception: `TypstCompilationError` (`typsphinx/pdf.py`) for Typst compilation failures
+
+**Logs:**
+- Sphinx logging framework (`sphinx.util.logging`) via standard `logger.getLogger(__name__)` pattern
+- No centralized logging service; logs output to stderr/console during build
+
+## CI/CD & Deployment
+
+**Hosting:**
+- GitHub - Repository hosting and GitHub Pages for documentation
+- PyPI - Package distribution
+
+**CI Pipeline:**
+- GitHub Actions (`.github/workflows/`)
+  - `ci.yml`: Multi-matrix testing (Python 3.9-3.12, ubuntu/macos/windows), linting, type checking, coverage, build validation
+  - `release.yml`: Release orchestration — validation, build, PyPI publish (production + TestPyPI for pre-releases), GitHub Release creation
+  - `docs.yml`: Documentation build and deployment to GitHub Pages
+  - Triggers: Pushes to `main` and `develop`, PRs, tags matching `v*`, workflow dispatch
+
+**Coverage Service:**
+- Codecov - Code coverage tracking
+  - Integration: `codecov/codecov-action@v5` in CI workflow
+  - Token: `secrets.CODECOV_TOKEN`
+  - Upload: Coverage reports from pytest via `--cov-report=xml`
+
+**Documentation Deployment:**
+- GitHub Pages - Auto-deployed from `main` branch
+  - Deployment action: `peaceiris/actions-gh-pages@v4`
+  - Source: `docs/_build/multilang/` (multi-language HTML build)
+  - URL: `https://yusabo90002.github.io/typsphinx/`
+
+## Environment Configuration
+
+**Required for Local Development:**
+- No env vars required (Python stdlib + installed packages)
+- Development environment: Nix flake or `uv sync`
+
+**Required for CI/CD (GitHub Secrets):**
+- `CODECOV_TOKEN` - Codecov coverage uploads (optional; `fail_ci_if_error: false`)
+- `PYPI_API_TOKEN` - Production PyPI publishing (trusted publishing workflow)
+- `TEST_PYPI_API_TOKEN` - TestPyPI pre-release publishing
+- `GITHUB_TOKEN` - Automatic in GitHub Actions for release artifacts and pages deployment
+
+**Secrets location:**
+- GitHub repository secrets (`.github/` workflows read via `${{ secrets.VAR_NAME }}`)
+- Local: `.env*` files (if used) are `.gitignore`d and not tracked
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- GitHub webhooks - Automatic triggers for:
+  - Pull request events → runs CI
+  - Push to `main` → builds and deploys documentation to GitHub Pages
+  - Tag push `v*` → triggers release workflow
+
+**Outgoing:**
+- None at code level
+- CI notifications: GitHub Actions status checks on PRs
+- Documentation: Deployed to GitHub Pages (static push, no callback)
+
+## Sphinx Configuration System
+
+**Registered Config Values** (`typsphinx/__init__.py`):
+- `typst_documents` - List of documents to build
+- `typst_template` - Custom Typst template path
+- `typst_template_mapping` - Document-to-template mapping
+- `typst_toctree_defaults` - Table of contents defaults
+- `typst_use_mitex` - Enable LaTeX math support (default: True)
+- `typst_elements` - Custom element mappings
+- `typst_package` - Custom Typst package name
+- `typst_package_imports` - List of Typst package imports
+- `typst_template_function` - Custom template rendering function
+- `typst_authors` - Author metadata
+- `typst_author_params` - Author parameter configuration
+- `typst_output_dir` - Output directory path (default: `_build/typst`)
+- `typst_debug` - Debug mode flag
+- `typst_template_assets` - Additional template assets to include
+
+**Configured in:**
+- Sphinx `conf.py` (user's documentation project)
+
+---
+
+*Integration audit: 2026-07-04*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,110 @@
+# Technology Stack
+
+**Analysis Date:** 2026-07-04
+
+## Languages
+
+**Primary:**
+- Python 3.9+ - Core implementation language for the Sphinx extension
+
+**Secondary:**
+- Typst - Output format for documentation (generated, not written)
+- reStructuredText - Input format for documentation
+- YAML - Configuration for GitHub Actions and Dependabot
+
+## Runtime
+
+**Environment:**
+- Python 3.9, 3.10, 3.11, 3.12 (supported versions per `pyproject.toml`)
+
+**Package Manager:**
+- uv - Fast Python package and virtual environment manager
+- Lockfile: `uv.lock` (present)
+
+## Frameworks
+
+**Core:**
+- Sphinx 5.0+ - Documentation generation framework
+- docutils 0.18+ - Markup language processing system
+
+**Testing:**
+- pytest 7.0+ - Test runner
+- pytest-cov 4.0+ - Code coverage plugin
+- sphinx-testing 1.0+ - Sphinx extension testing utilities
+
+**Build/Dev:**
+- black 23.0+ - Code formatter
+- ruff 0.1.0+ - Fast Python linter
+- mypy 1.0+ - Static type checker
+- tox 4.0+ - Test automation tool
+- tox-uv 1.0+ - Uv integration for tox
+- twine 5.0+ - Package upload utility
+- build 1.0+ - Python package builder
+- pre-commit 3.0+ - Git hook framework
+
+## Key Dependencies
+
+**Critical:**
+- typst 0.14.1+ - Typst compiler as Python package; core to PDF generation via `typsphinx.pdf.compile_typst_to_pdf()`
+- docutils 0.18+ - Core dependency for AST processing of reStructuredText
+
+**Infrastructure:**
+- setuptools 65.0+ - Package build backend
+- wheel - Wheel format distribution
+
+**Documentation:**
+- furo 2024.0+ - Clean, modern Sphinx theme (`docs` extra)
+- sphinx-autodoc-typehints 1.0+ - Type hint support in documentation
+- sphinx-intl 2.0+ - Internationalization support for multi-language docs
+
+**Type Hints:**
+- types-docutils 0.18+ - Type stubs for docutils
+
+## Configuration
+
+**Environment:**
+- No `.env` files required; all configuration via Python code in Sphinx `conf.py`
+- Build configuration: `pyproject.toml` (project metadata, build system, tool settings)
+
+**Build:**
+- `pyproject.toml`: Main project configuration, entry points, test setup
+  - Entry points: `[project.entry-points."sphinx.builders"]` registers `typst` and `typstpdf` builders
+- `tox.ini`: Test environment definitions for tox-based testing
+- `flake.nix`: Nix development shell for reproducible development environment
+- `uv.lock`: Dependency lock file for deterministic builds
+
+**Formatting & Linting:**
+- `.black` in `pyproject.toml`: Line length 88, targets Python 3.9+
+- `.ruff` in `pyproject.toml`: Linter with E, F, W, I, N, UP, B, A, C4, T20 rules; line length 88
+- `.mypy` in `pyproject.toml`: Type checking (warn_return_any=false, check_untyped_defs=false)
+
+## Platform Requirements
+
+**Development:**
+- Linux, macOS, Windows (CI tests on ubuntu-latest, macos-latest, windows-latest)
+- Nix development shell with:
+  - Python 3
+  - Node.js (for CLI/tooling)
+  - pnpm (package manager)
+  - uv (Python dependency manager)
+  - Git
+
+**Production:**
+- Any Python 3.9+ environment with pip/uv
+- Distribution: PyPI package registry
+- No system-level Typst compiler required (bundled via typst-py package)
+
+## Package Discovery & Entry Points
+
+**Sphinx Builder Registration:**
+- Location: `pyproject.toml` `[project.entry-points."sphinx.builders"]`
+- `typst = "typsphinx"` - Typst builder (generates `.typ` files)
+- `typstpdf = "typsphinx"` - PDF builder (generates PDFs directly)
+- Auto-discovered by Sphinx via entry points (no manual extension registration required)
+
+**Template Assets:**
+- Location: `typsphinx/templates/*.typ` (packaged via `[tool.setuptools.package-data]`)
+
+---
+
+*Stack analysis: 2026-07-04*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,219 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-07-04
+
+## Directory Layout
+
+```
+typsphinx/
+├── typsphinx/                 # Main package
+│   ├── __init__.py            # Sphinx extension entry point (setup function)
+│   ├── builder.py             # TypstBuilder and TypstPDFBuilder classes
+│   ├── writer.py              # TypstWriter class (document translation coordinator)
+│   ├── translator.py          # TypstTranslator class (docutils node visitor)
+│   ├── template_engine.py     # TemplateEngine class (template loading, rendering)
+│   ├── pdf.py                 # PDF compilation utilities
+│   └── templates/             # Default Typst templates
+│       └── base.typ           # Default base template
+├── tests/                     # Test suite
+│   ├── conftest.py            # pytest configuration and shared fixtures
+│   ├── roots/                 # Test root directories for Sphinx projects
+│   │   └── test-basic/        # Minimal test Sphinx project
+│   ├── fixtures/              # Integration test fixtures
+│   │   ├── integration_basic/
+│   │   ├── integration_multi_doc/
+│   │   ├── integration_nested_toctree/
+│   │   ├── integration_multi_level/
+│   │   ├── integration_sibling/
+│   │   └── integration_math_figures/
+│   ├── test_*.py              # Test files (unit, integration, documentation)
+│   └── test_builder.py        # Builder tests
+├── docs/                      # Documentation source
+│   ├── source/                # Sphinx documentation source
+│   │   ├── conf.py            # Sphinx configuration for documentation
+│   │   ├── index.rst          # Documentation index
+│   │   ├── api/               # API documentation
+│   │   ├── examples/          # Example documentation
+│   │   ├── user_guide/        # User guide documentation
+│   │   ├── _static/           # Static assets
+│   │   └── _templates/        # Sphinx templates
+│   └── locale/                # i18n translation files
+├── examples/                  # Example projects
+│   ├── basic/                 # Basic example
+│   ├── advanced/              # Advanced example with custom template
+│   └── charged-ieee/          # IEEE template examples
+├── pyproject.toml             # Project metadata and dependencies
+├── tox.ini                    # tox test runner configuration
+├── flake.nix                  # Nix development environment
+├── README.md                  # Project README
+├── CHANGELOG.md               # Version history
+└── LICENSE                    # MIT License
+```
+
+## Directory Purposes
+
+**typsphinx/ (main package):**
+- Purpose: Core extension implementation
+- Contains: Sphinx builder, translator, template engine, PDF utilities
+- Key files: __init__.py (entry point), builder.py, writer.py, translator.py, template_engine.py, pdf.py
+- Deployed: Installed to site-packages via setuptools
+
+**tests/:**
+- Purpose: Test suite for quality assurance
+- Contains: Unit tests, integration tests, documentation tests, test fixtures
+- Key files: conftest.py (shared fixtures), test_*.py files
+- Structure: roots/ for Sphinx test projects, fixtures/ for integration test data
+- Run: `pytest` or `tox`
+
+**docs/:**
+- Purpose: User-facing documentation
+- Contains: Sphinx documentation source (RST files)
+- Key files: conf.py (documentation build config), source/index.rst (manual homepage)
+- Subdirectories: api/ (API reference), user_guide/ (tutorials), examples/ (sample usage)
+- Deployment: Built to HTML/Typst for publication
+
+**examples/:**
+- Purpose: Example Sphinx projects demonstrating typsphinx usage
+- Contains: Complete Sphinx project directories with source files, conf.py
+- Key subdirectories:
+  - basic/: Minimal example showing basic setup
+  - advanced/: Example with custom template
+  - charged-ieee/: IEEE template integration examples (approach1, approach2)
+
+## Key File Locations
+
+**Entry Points:**
+- `typsphinx/__init__.py`: Sphinx extension setup function; registers builders and config values
+- `typsphinx/builder.py:TypstBuilder.write()`: Main build orchestration loop
+
+**Configuration:**
+- `pyproject.toml`: Project metadata, dependencies, tool configs (black, ruff, mypy, pytest)
+- `typsphinx/__init__.py`: Extension configuration value registration
+
+**Core Logic:**
+- `typsphinx/builder.py`: Build lifecycle management (TypstBuilder, TypstPDFBuilder)
+- `typsphinx/writer.py`: Translation orchestration and template application
+- `typsphinx/translator.py`: Node-to-Typst conversion (visitor pattern implementation)
+- `typsphinx/template_engine.py`: Template loading, parameter mapping, rendering
+
+**Templates:**
+- `typsphinx/templates/base.typ`: Default Typst template bundled with package
+
+**Testing:**
+- `tests/conftest.py`: pytest fixtures (rootdir, sample_doctree, temp_sphinx_app)
+- `tests/test_*.py`: Individual test modules
+- `tests/roots/test-basic/`: Minimal Sphinx project for testing
+- `tests/fixtures/integration_*/`: Integration test project structures
+
+**Utilities:**
+- `typsphinx/pdf.py`: Typst-to-PDF compilation wrapper (compile_typst_to_pdf function)
+
+## Naming Conventions
+
+**Files:**
+- Module files: lowercase with underscores (`builder.py`, `template_engine.py`)
+- Test files: `test_<subject>.py` (e.g., `test_builder.py`, `test_admonitions.py`)
+- Template files: `.typ` extension (Typst markup)
+- Config files: `conf.py` (Sphinx convention)
+
+**Directories:**
+- Package directory: singular module name (`typsphinx/`)
+- Test directory: `tests/`
+- Documentation: `docs/`
+- Examples: `examples/`
+- Fixtures: grouped in `tests/fixtures/<test_name>/`
+- Test root projects: `tests/roots/test-<name>/`
+
+**Classes:**
+- Builder classes: CamelCase, end with "Builder" (`TypstBuilder`, `TypstPDFBuilder`)
+- Translator classes: CamelCase, end with "Translator" (`TypstTranslator`)
+- Writer classes: CamelCase, end with "Writer" (`TypstWriter`)
+- Engine classes: CamelCase, end with "Engine" (`TemplateEngine`)
+- Exception classes: CamelCase, end with "Error" or "Exception" (`TypstCompilationError`)
+
+**Functions:**
+- Builder methods: lowercase with underscores (`get_outdated_docs`, `write_doc`, `prepare_writing`)
+- Visitor methods: `visit_<node_type>`, `depart_<node_type>` (e.g., `visit_paragraph`, `depart_emphasis`)
+- Utility functions: lowercase with underscores (`compile_typst_to_pdf`, `check_typst_available`)
+
+**Variables:**
+- State flags: `in_<state>` (e.g., `in_table`, `in_figure`, `in_paragraph`)
+- Content buffers: `<content>_buffer` or `<content>` (e.g., `body`, `figure_caption`)
+- Stack/list tracking: `<item>_stack` (e.g., `list_stack`)
+- Metadata/config: descriptive names (e.g., `sphinx_metadata`, `parameter_mapping`)
+
+## Where to Add New Code
+
+**New Feature (e.g., supporting a new docutils node type):**
+- Primary code: Add visit_<node> and depart_<node> methods in `typsphinx/translator.py`
+- Tests: Create or update test file (e.g., `tests/test_<feature>.py`)
+- Integration: If affects output format, may need template updates
+- Config: If feature requires configuration, add via setup() in `typsphinx/__init__.py`
+
+**New Component/Module:**
+- Implementation: Create new file in `typsphinx/` directory (e.g., `typsphinx/my_feature.py`)
+- Follow naming: lowercase with underscores
+- Export in `typsphinx/__init__.py` if needed by other modules
+- Update imports in affected modules
+
+**New Builder or Format:**
+- Implementation: Extend `TypstBuilder` in `typsphinx/builder.py`
+- Override methods: `write_doc()`, `finish()`, etc. as needed
+- Register in setup() function in `typsphinx/__init__.py`
+- Add to entry point in `pyproject.toml` if needed
+
+**Utilities and Helpers:**
+- Shared helpers: Place in relevant module (e.g., string escaping in `translator.py`, path handling in `builder.py`)
+- Cross-module utilities: Create new module in `typsphinx/` (e.g., `typsphinx/utils.py`)
+- Avoid creating separate utility module if only used once
+
+**Tests:**
+- Unit tests: Create `tests/test_<component>.py` for new component
+- Integration tests: Add to `tests/fixtures/integration_<test_name>/` with conf.py and source RST
+- Fixtures: Add pytest fixtures to `tests/conftest.py` if reusable
+- Test structure: Follow existing patterns (use conftest fixtures, test apps)
+
+**Documentation:**
+- API docs: Add docstrings to classes/functions (parsed by sphinx-autodoc-typehints)
+- User guide: Add to `docs/source/user_guide/`
+- Examples: Create example project in `examples/<name>/` with README and source
+- Configuration examples: Document in `docs/source/api/configuration.rst`
+
+## Special Directories
+
+**typsphinx/templates/:**
+- Purpose: Bundled default Typst templates
+- Generated: No (committed to git)
+- Committed: Yes
+- Usage: Loaded by TemplateEngine if no custom template specified
+- Access: Via package_dir in `template_engine.py:TemplateEngine.get_default_template_path()`
+
+**tests/roots/:**
+- Purpose: Minimal Sphinx projects for unit tests
+- Generated: No
+- Committed: Yes
+- Contents: Each test-<name>/ contains conf.py and index.rst
+- Access: Referenced by SphinxTestApp fixture in tests
+
+**tests/fixtures/:**
+- Purpose: Test data structures for integration tests
+- Generated: No
+- Committed: Yes
+- Structure: Each integration_<test_name>/ contains complete Sphinx project with source/ subdirectory
+- Includes: conf.py, index.rst, and test-specific content (chapters, complex structures, images)
+
+**docs/locale/:**
+- Purpose: i18n translation files
+- Generated: Partially (translations, pot files updated via Sphinx intl)
+- Committed: Yes (for completed translations)
+- Contents: Organized by language code (e.g., ja/, de/) with LC_MESSAGES subdirectories
+
+**build/:**
+- Purpose: Build output directory (created during tests and documentation builds)
+- Generated: Yes (by sphinx-build, tox, etc.)
+- Committed: No (.gitignore excludes)
+- Contents: Generated artifacts (HTML, Typst, PDF, etc.)
+
+---
+
+*Structure analysis: 2026-07-04*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,324 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-07-04
+
+## Test Framework
+
+**Runner:**
+- pytest (version ≥ 7.0)
+- Configuration: `pyproject.toml` lines 75-84
+- Config file: `pyproject.toml` (pytest.ini_options section)
+
+**Assertion Library:**
+- Built-in pytest assertions (`assert` statements)
+- Error messages use f-strings and context: `assert result.returncode == 0, f"sphinx-build failed:\nSTDOUT:\n{result.stdout}..."`
+
+**Run Commands:**
+```bash
+# Run all tests
+pytest tests/
+
+# Run with coverage
+pytest --cov=typsphinx --cov-report=term-missing --cov-report=html tests/
+
+# Run specific test file
+pytest tests/test_builder.py
+
+# Run tests matching pattern
+pytest tests/ -k "config"
+
+# Watch mode (use pytest-watch plugin)
+ptw
+```
+
+**Tox environments (from tox.ini):**
+```bash
+# Run all test environments
+tox
+
+# Run specific environment
+tox -e py311      # Python 3.11 tests
+tox -e lint       # Code style checks (black, ruff)
+tox -e type       # Type checking (mypy)
+tox -e cov        # Tests with coverage
+tox -e docs       # Build documentation
+```
+
+## Test File Organization
+
+**Location:**
+- Tests co-located in `/home/yuta/Documents/typsphinx/tests/` directory
+- Separate from source code (not alongside source files)
+- Fixture directory: `tests/fixtures/` for sample Sphinx projects
+- Fixture root: `tests/roots/` for sphinx.testing.fixtures
+
+**Naming:**
+- Test files: `test_*.py` pattern
+- Test classes: `Test*` pattern (e.g., `TestBasicSphinxProjectBuild`)
+- Test functions: `test_*` pattern (e.g., `test_typst_builder_can_be_imported`)
+- Fixtures: Function names describe what they provide (e.g., `temp_sphinx_app`, `sample_doctree`)
+
+**Structure:**
+```
+tests/
+├── conftest.py                        # Global fixtures and configuration
+├── fixtures/                          # Sample Sphinx projects for integration tests
+│   └── integration_basic/
+│       ├── conf.py
+│       └── index.rst
+├── test_admonitions.py               # Feature tests (admonitions rendering)
+├── test_builder.py                   # Builder class tests
+├── test_config.py                    # Configuration handling
+├── test_entry_points.py              # Package entry points
+├── test_integration_basic.py          # Full build process tests
+├── test_integration_advanced.py       # Complex feature integration
+├── test_template_*.py                 # Template engine features
+├── test_math_*.py                     # Math rendering variants
+└── ... (40+ test files total)
+```
+
+## Test Structure
+
+**Global Setup (conftest.py):**
+```python
+pytest_plugins = "sphinx.testing.fixtures"
+
+@pytest.fixture(scope="session")
+def rootdir():
+    """Root directory for test files."""
+    return Path(__file__).parent.absolute() / "roots"
+```
+
+**Session-scoped Fixtures:**
+- `rootdir`: Returns path to test roots directory (persistent for entire test session)
+
+**Function-scoped Fixtures:**
+- `sample_doctree`: Creates minimal docutils document with section and paragraph
+- `temp_sphinx_app`: Creates temporary Sphinx app with conf.py and index.rst
+- `sphinx_config`: Dictionary with sample Sphinx configuration
+- `mock_builder`: Mock builder object for unit testing translator/writer
+
+**Test Class Pattern:**
+```python
+class TestBasicSphinxProjectBuild:
+    """Test building a basic Sphinx project with typst builder (Task 15.1)."""
+
+    def test_basic_project_files_exist(self, basic_project_dir):
+        """Test that the basic project fixture has required files."""
+        assert (basic_project_dir / "conf.py").exists()
+
+    def test_sphinx_build_typst_succeeds(self, basic_project_dir, temp_build_dir):
+        """Test that sphinx-build -b typst succeeds for basic project."""
+        result = subprocess.run([...], capture_output=True, text=True)
+        assert result.returncode == 0
+```
+
+## Mocking
+
+**Framework:** 
+- Manual mocks using class definitions (no pytest-mock)
+- Example: `conftest.py` lines 98-114 (MockConfig, MockDomains, MockEnv, MockBuilder)
+
+**Mock Patterns:**
+```python
+class MockConfig:
+    pass
+
+class MockBuilder:
+    config = MockConfig()
+    env = MockEnv()
+
+# Usage in tests
+def mock_builder():
+    """Create a mock builder for testing."""
+    return MockBuilder()
+```
+
+**What to Mock:**
+- Sphinx application dependencies for unit tests
+- Builder config and env objects when testing translator logic
+- File system operations when testing configuration loading (use tmp_path)
+
+**What NOT to Mock:**
+- docutils nodes: Use real nodes for document tree testing
+- Sphinx builders: Use SphinxTestApp for realistic builder behavior
+- File I/O in integration tests: Use actual temporary files (tmp_path fixture)
+
+## Fixtures and Factories
+
+**Test Data Patterns:**
+
+Directory-based fixtures (conftest.py):
+```python
+@pytest.fixture(scope="session")
+def rootdir():
+    """Root directory for test files."""
+    return Path(__file__).parent.absolute() / "roots"
+```
+
+Temporary directory fixtures:
+```python
+def test_custom_config(tmp_path):
+    """Test custom configuration loading."""
+    srcdir = tmp_path / "source"
+    srcdir.mkdir()
+    conf_py = srcdir / "conf.py"
+    conf_py.write_text("...")  # Write test config
+```
+
+Document tree factory:
+```python
+@pytest.fixture
+def sample_doctree() -> nodes.document:
+    """Create a sample doctree for testing."""
+    from docutils.parsers.rst import states
+    from docutils.utils import Reporter
+    
+    reporter = Reporter("", 2, 4)
+    doc = nodes.document("", reporter=reporter)
+    doc.settings = states.Struct()
+    # ... setup document
+    return doc
+```
+
+**Sphinx App Factory:**
+```python
+@pytest.fixture
+def temp_sphinx_app(tmp_path: Path) -> SphinxTestApp:
+    """Create a temporary Sphinx application for testing."""
+    srcdir = tmp_path / "source"
+    srcdir.mkdir()
+    
+    # Create minimal conf.py
+    conf_py = srcdir / "conf.py"
+    conf_py.write_text("extensions = ['typsphinx']\n...")
+    
+    # Create minimal index.rst
+    index_rst = srcdir / "index.rst"
+    index_rst.write_text("Test Document\n...")
+    
+    builddir = tmp_path / "build"
+    app = SphinxTestApp(srcdir=srcdir, builddir=builddir)
+    return app
+```
+
+**Location:**
+- Shared fixtures in `tests/conftest.py`
+- Test-specific fixtures defined in individual test modules with `@pytest.fixture` decorator
+- Example: `test_integration_basic.py` lines 14-29 define `fixtures_dir`, `basic_project_dir`, `temp_build_dir`
+
+## Coverage
+
+**Requirements:** No specific coverage target enforced, but cov environment available
+
+**View Coverage:**
+```bash
+# Generate HTML coverage report
+tox -e cov
+
+# Open report
+open htmlcov/index.html
+
+# View in terminal
+pytest --cov=typsphinx --cov-report=term-missing tests/
+```
+
+**Command from tox.ini (line 45):**
+```bash
+pytest --cov=typsphinx --cov-report=term-missing --cov-report=html tests/
+```
+
+## Test Types
+
+**Unit Tests:**
+- Scope: Single class or function in isolation
+- Location: `tests/test_*.py` files testing specific modules
+- Example: `test_builder.py` tests TypstBuilder class methods independently
+- Approach: Use mock fixtures for dependencies, assert on return values
+- Sample: Lines 11-15 test TypstBuilder can be imported and inherits from Builder
+
+**Integration Tests:**
+- Scope: Multiple components working together or full build process
+- Location: `tests/test_integration_*.py` files (e.g., test_integration_basic.py)
+- Approach: Use SphinxTestApp to build actual Sphinx projects, subprocess.run for sphinx-build
+- Sample: Lines 40-59 in test_integration_basic.py run actual sphinx-build command and verify .typ file generation
+- Subprocess pattern:
+  ```python
+  result = subprocess.run(
+      ["uv", "run", "sphinx-build", "-b", "typst", str(basic_project_dir), str(temp_build_dir)],
+      capture_output=True,
+      text=True,
+  )
+  assert result.returncode == 0, f"sphinx-build failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+  ```
+
+**E2E Tests:**
+- Not formalized; integration tests serve as E2E validation
+- Full build + verification pattern in test_integration_*.py files
+
+## Common Patterns
+
+**Async Testing:**
+- Not used; this is a synchronous Python library
+
+**Error Testing:**
+- Verify error conditions raise expected exceptions
+- Assert on exception attributes
+- Example: Test that missing required module raises ImportError with helpful message (pdf.py lines 70-78)
+
+**File System Testing:**
+- Use pytest's `tmp_path` fixture for temporary directories
+- Write test files and assert on generated outputs
+- Example: `test_integration_basic.py` line 77-79 verifies generated .typ file exists
+
+**Parametrized Tests:**
+- Not detected in current test suite
+- Could be used for testing multiple input variations
+
+**Markers:**
+From `pyproject.toml` lines 81-84:
+```ini
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests as integration tests",
+]
+```
+
+Usage:
+```python
+@pytest.mark.slow
+def test_slow_operation():
+    pass
+
+@pytest.mark.integration
+def test_full_build():
+    pass
+
+# Run without slow tests
+pytest -m "not slow"
+
+# Run only integration tests
+pytest -m integration
+```
+
+## Test Execution Details
+
+**Test Discovery:**
+- Python files: `test_*.py`
+- Test classes: `Test*`
+- Test functions: `test_*` (configured in pyproject.toml line 79)
+
+**Test Settings (pyproject.toml lines 75-84):**
+- testpaths: ["tests"]
+- python_files: ["test_*.py"]
+- python_classes: ["Test*"]
+- python_functions: ["test_*"]
+- addopts: "-v --strict-markers" (verbose output, enforce marker registration)
+
+**Error Message Format:**
+- Multi-line detailed output on assertion failure
+- Context provided via f-strings: `f"sphinx-build failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"`
+
+---
+
+*Testing analysis: 2026-07-04*


### PR DESCRIPTION
## 概要

GSD の `/gsd-map-codebase` で、4つの mapper エージェント（並列）が既存コードベースを分析し、構造化ドキュメント7点を `.planning/codebase/` に生成しました。今後の計画・実装のリファレンスとして利用します。

## 追加ドキュメント（計 1,412 行）

| ドキュメント | 行数 | 内容 |
|---|---|---|
| `STACK.md` | 110 | 言語・ランタイム・フレームワーク・依存関係 |
| `INTEGRATIONS.md` | 124 | 外部API・DB・認証・webhook |
| `ARCHITECTURE.md` | 304 | パターン・レイヤー・データフロー・エントリポイント |
| `STRUCTURE.md` | 219 | ディレクトリ構成・命名規則 |
| `CONVENTIONS.md` | 165 | コードスタイル・命名・エラー処理 |
| `TESTING.md` | 324 | テストフレームワーク・構成・カバレッジ |
| `CONCERNS.md` | 166 | 技術的負債・既知の問題・懸念点 |

## 補足

- 生成後、全ドキュメントの存在・非空・シークレット混入なしを検証済み
- `.planning/` は git 管理対象（`.claude/` のみ gitignore）

🤖 Generated with [Claude Code](https://claude.com/claude-code)