### PR TITLE
fix(release): tomllib/tomli fallback in release.yml version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Verify version matches pyproject.toml
         run: |
-          PYPROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          PYPROJECT_VERSION=$(uv run python -c "import sys, importlib; tomllib = importlib.import_module('tomllib' if sys.version_info >= (3, 11) else 'tomli'); print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           TAG_VERSION="${{ steps.version.outputs.version }}"
           echo "pyproject.toml version: $PYPROJECT_VERSION"
           echo "Tag version: $TAG_VERSION"


### PR DESCRIPTION
## Problem
The `v0.4.4` tag push triggered `release.yml`, which **failed at the Validate Release job**: the *Verify version matches pyproject.toml* step runs `uv run python -c "import tomllib ..."` on Python 3.10, but `tomllib` is stdlib-only on 3.11+ → `ModuleNotFoundError: No module named 'tomllib'`. No PyPI publish or GitHub Release was created (validate is the first gate).

## Root cause
Phase 3 / PYVER-02 reconciled `release.yml`'s hardcoded Python to the 3.10 floor. The version-verify step's `tomllib` usage was never exercised because it only runs on a `v*` tag push — a release-only latent regression (the D-11 "tag-gated" class).

## Fix
Single-line `tomllib`/`tomli` fallback (same pattern as `docs/source/conf.py`). `tomli>=2.0; python_version < '3.11'` is already in the `dev` extra that the validate job installs, so it resolves on 3.10.

## After merge
The `v0.4.4` tag (never published) is moved to the fixed commit and re-pushed to re-run the release cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)