### PR TITLE
docs(v0.4.4): record release outcome (PyPI ship, D-11 resolved, release.yml fix)

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -10,8 +10,14 @@ A historical record of shipped versions. Full detail per milestone lives in `.pl
 **Closeout:** verified_closeout (pre-close artifact audit clear; all 5 phases verified)
 **Phases:** 5 (1–5) · **Plans:** 15 · **Tasks:** ~35
 **Requirements:** 23/23 v1 requirements complete · **Known gaps:** none
-**Git:** milestone work merged to `main` via PRs #104 / #105 / #106; tagged `v0.4.4`
+**Git:** milestone work merged to `main` via PRs #104 / #105 / #106; close + release-prep via #109; tagged `v0.4.4` (on `main` dae500a)
+**Released:** PyPI `typsphinx 0.4.4` (wheel + sdist) + GitHub Release, via release run 28731646924 (green end-to-end)
 **Code delta (milestone scope):** ~15 source/config files, +217 / −1202 lines (net, incl. `uv.lock` collapse)
+
+> **Release note:** The first `v0.4.4` tag push failed at the `release.yml` Validate gate — the
+> version-verify step imported stdlib-only `tomllib` on the 3.10 floor (a PYVER-02 side effect
+> only exercised at tag time). Fixed with a `tomllib`/`tomli` fallback (PR #110), tag re-pointed,
+> release re-run green. This also resolved D-11 (`softprops/action-gh-release@v3` ran green).
 
 **Delivered:** Restored a fully green CI pipeline on `main` — lint, the 3-OS × Python 3.10–3.13 test matrix (19 jobs), coverage, and the docs PDF build — by pinning the runtime dependency graph back to a known-good, reproducible combination, then modernized the Python floor and dev tooling and installed durability guardrails so the drift can't silently recur.
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -33,7 +33,7 @@ Every CI job passes again on `main` — lint, the full test matrix, coverage, an
 
 <!-- Milestone v0.4.4 (green + modernized + guarded CI) complete as of Phase 5. -->
 
-_None — all milestone v0.4.4 requirements validated across Phases 1–5. (D-11 `softprops@v3` tag-gated runtime confirmation is a signed-off deferral to the next release tag, not an open requirement.)_
+_None — all milestone v0.4.4 requirements validated across Phases 1–5. (D-11 `softprops@v3` tag-gated runtime confirmation is now **resolved**: the `Create GitHub Release` job ran green in the v0.4.4 release run.)_
 
 ### Out of Scope
 
@@ -70,7 +70,8 @@ _None — all milestone v0.4.4 requirements validated across Phases 1–5. (D-11
 | Bump artifact actions to node24: upload-artifact@v5→v7, download-artifact@v6→v8 (D-03 AMENDED 2026-07-05, Phase 4) | Post-research: v5/v6 still declare node20, which GitHub removes from hosted runners 2026-09-16; the original "already at latest majors" premise was wrong | Applied across ci.yml/docs.yml/release.yml (7 + 3 occurrences), runtime-verified node24; Phase 4 CI green |
 | Remove stale `Test Python 3.9 on ubuntu-latest` required status check from `main` branch protection, add 3.13 (Phase 4) | Phase-3 leftover: 3.9 was dropped from the CI matrix but the required-check list wasn't updated, leaving a permanent "Expected — waiting for status" pending that blocked PR #105 despite all 18 jobs green | Applied via `gh api PATCH`; PR #105 became MERGEABLE/CLEAN. Required set now ubuntu 3.10–3.13 + Lint/Type/Coverage/Build |
 | `softprops/action-gh-release@v2` node20 straggler tracked, not force-bumped in Phase 4 | Outside 04-02's authorized edit scope (artifact-actions only) and needs its own verification; `@v3` exists and is node24 | Deferred to Phase 5 (durability-guardrails) as a tracked item, not silently closed |
-| Close the milestone with durability guardrails: `--locked` lockfile-currency gate + standalone weekly `drift.yml` + `sphinx-typst-stack` Dependabot group + README CI badge; softprops@v3 (Phase 5, D-01..D-11) | Install anti-drift controls so the silent multi-year rot this milestone fixed cannot recur unnoticed; keep the drift job advisory (never a required check, D-07) so it reports without blocking merges | Confirmed in Phase 5: PR #106 merged green (ci.yml 28730645396 / docs.yml 28730645381); drift.yml validated via post-merge `workflow_dispatch` (run 28730876125 success, no drift issue = no forward drift); D-11 softprops@v3 runtime confirmation signed-off as deferred to next release tag (tag-gated, Pitfall 3) |
+| Close the milestone with durability guardrails: `--locked` lockfile-currency gate + standalone weekly `drift.yml` + `sphinx-typst-stack` Dependabot group + README CI badge; softprops@v3 (Phase 5, D-01..D-11) | Install anti-drift controls so the silent multi-year rot this milestone fixed cannot recur unnoticed; keep the drift job advisory (never a required check, D-07) so it reports without blocking merges | Confirmed in Phase 5: PR #106 merged green (ci.yml 28730645396 / docs.yml 28730645381); drift.yml validated via post-merge `workflow_dispatch` (run 28730876125 success, no drift issue = no forward drift); D-11 softprops@v3 runtime confirmation RESOLVED at the v0.4.4 release: `Create GitHub Release` ran green (release run 28731646924, tag `v0.4.4`) |
+| Fix `release.yml` version-verify step: `import tomllib` → `tomllib`/`tomli` fallback (v0.4.4 release, PR #110) | PYVER-02's 3.10 floor reconciliation left the tag-only Validate step importing stdlib-only `tomllib` on 3.10; it crashed on the first `v0.4.4` tag push (a release-only regression not exercised by any PR CI) | Fixed on `main` (merge dae500a); re-pushed `v0.4.4` tag; release run 28731646924 green end-to-end → PyPI `typsphinx==0.4.4` (wheel+sdist) + GitHub Release published |
 
 ## Evolution
 
@@ -90,4 +91,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-07-05 after v0.4.4 milestone — green + modernized + guarded CI shipped across Phases 1–5*
+*Last updated: 2026-07-05 after v0.4.4 milestone — green + modernized + guarded CI shipped across Phases 1–5; released to PyPI (typsphinx 0.4.4) + GitHub Release, tag v0.4.4 on main*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -30,8 +30,8 @@ See: .planning/PROJECT.md (updated 2026-07-05)
 
 Phase: 05 — durability-guardrails (final phase)
 Plan: 4/4 complete
-Status: Milestone v0.4.4 complete & archived — Phase 5 verified (VERIFICATION.md: passed, 4/4 must-haves); PR #106 merged to main; tagged v0.4.4
-Last activity: 2026-07-05 — v0.4.4 milestone archived (milestones/v0.4.4-ROADMAP.md, v0.4.4-REQUIREMENTS.md); RETROSPECTIVE.md written
+Status: Milestone v0.4.4 SHIPPED — archived + tagged (v0.4.4 on main dae500a) + released to PyPI (typsphinx 0.4.4 wheel+sdist) + GitHub Release. Release run 28731646924 green end-to-end.
+Last activity: 2026-07-05 — v0.4.4 released: fixed a release.yml tomllib-on-3.10 regression (PR #110), re-pointed tag, published to PyPI + GitHub Release; D-11 (softprops@v3) resolved green
 
 Progress: [██████████] 100%
 


### PR DESCRIPTION
Closing doc-accuracy update after the v0.4.4 release shipped to PyPI.

- **D-11 resolved:** `softprops/action-gh-release@v3` ran green in the v0.4.4 release (was a signed-off deferral).
- **Key Decision added:** the `release.yml` `tomllib`→`tomli` fallback fix (PR #110).
- **STATE/MILESTONES:** record the PyPI publish (wheel+sdist) + GitHub Release and the tag-time regression.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)